### PR TITLE
Fixed bug in Next and Previous Button and bug in TypeaheadEditForm

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Enums/BibleBook.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/BibleBook.cs
@@ -1,4 +1,6 @@
-﻿using Ardalis.SmartEnum;
+﻿// Ignore Spelling: Abrv Songof Colossians Thessalonians Philemon
+
+using Ardalis.SmartEnum;
 using MyHebrewBible.Client.Features;
 
 namespace MyHebrewBible.Client.Enums;
@@ -365,7 +367,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstSamuelSE : BibleBook
 	{
 		public FirstSamuelSE() : base("FirstSamuel", 9) { }
-		public override string Title => "1Samuel";
+		public override string Title => "1 Samuel";
 		public override string Abrv => "1Sa";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.History;
 		public override BookEnum BookEnum => BookEnum.FirstSamuel;
@@ -387,7 +389,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondSamuelSE : BibleBook
 	{
 		public SecondSamuelSE() : base("SecondSamuel", 10) { }
-		public override string Title => "2Samuel";
+		public override string Title => "2 Samuel";
 		public override string Abrv => "2Sa";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.History;
 		public override BookEnum BookEnum => BookEnum.SecondSamuel;
@@ -409,7 +411,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstKingsSE : BibleBook
 	{
 		public FirstKingsSE() : base("FirstKings", 11) { }
-		public override string Title => "1Kings";
+		public override string Title => "1 Kings";
 		public override string Abrv => "1Ki";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.History;
 		public override BookEnum BookEnum => BookEnum.FirstKings;
@@ -431,7 +433,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondKingsSE : BibleBook
 	{
 		public SecondKingsSE() : base("SecondKings", 12) { }
-		public override string Title => "2Kings";
+		public override string Title => "2 Kings";
 		public override string Abrv => "2Ki";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.History;
 		public override BookEnum BookEnum => BookEnum.SecondKings;
@@ -453,7 +455,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstChroniclesSE : BibleBook
 	{
 		public FirstChroniclesSE() : base("FirstChronicles", 13) { }
-		public override string Title => "1Chronicles";
+		public override string Title => "1 Chronicles";
 		public override string Abrv => "1Ch";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.History;
 		public override BookEnum BookEnum => BookEnum.FirstChronicles;
@@ -475,7 +477,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondChroniclesSE : BibleBook
 	{
 		public SecondChroniclesSE() : base("SecondChronicles", 14) { }
-		public override string Title => "2Chronicles";
+		public override string Title => "2 Chronicles";
 		public override string Abrv => "2Ch";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.History;
 		public override BookEnum BookEnum => BookEnum.SecondChronicles;
@@ -1180,7 +1182,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstCorinthiansSE : BibleBook
 	{
 		public FirstCorinthiansSE() : base("FirstCorinthians", 46) { }
-		public override string Title => "1Corinthians";
+		public override string Title => "1 Corinthians";
 		public override string Abrv => "1Co";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.PaulsEpistles;
 		public override BookEnum BookEnum => BookEnum.FirstCorinthians;
@@ -1202,7 +1204,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondCorinthiansSE : BibleBook
 	{
 		public SecondCorinthiansSE() : base("SecondCorinthians", 47) { }
-		public override string Title => "2Corinthians";
+		public override string Title => "2 Corinthians";
 		public override string Abrv => "2Co";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.PaulsEpistles;
 		public override BookEnum BookEnum => BookEnum.SecondCorinthians;
@@ -1312,7 +1314,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstThessaloniansSE : BibleBook
 	{
 		public FirstThessaloniansSE() : base("FirstThessalonians", 52) { }
-		public override string Title => "1Thessalonians";
+		public override string Title => "1 Thessalonians";
 		public override string Abrv => "1Th";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.PaulsEpistles;
 		public override BookEnum BookEnum => BookEnum.FirstThessalonians;
@@ -1334,7 +1336,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondThessaloniansSE : BibleBook
 	{
 		public SecondThessaloniansSE() : base("SecondThessalonians", 53) { }
-		public override string Title => "2Thessalonians";
+		public override string Title => "2 Thessalonians";
 		public override string Abrv => "2Th";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.PaulsEpistles;
 		public override BookEnum BookEnum => BookEnum.SecondThessalonians;
@@ -1356,7 +1358,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstTimothySE : BibleBook
 	{
 		public FirstTimothySE() : base("FirstTimothy", 54) { }
-		public override string Title => "1Timothy";
+		public override string Title => "1 Timothy";
 		public override string Abrv => "1Ti";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.PaulsEpistles;
 		public override BookEnum BookEnum => BookEnum.FirstTimothy;
@@ -1378,7 +1380,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondTimothySE : BibleBook
 	{
 		public SecondTimothySE() : base("SecondTimothy", 55) { }
-		public override string Title => "2Timothy";
+		public override string Title => "2 Timothy";
 		public override string Abrv => "2Ti";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.PaulsEpistles;
 		public override BookEnum BookEnum => BookEnum.SecondTimothy;
@@ -1488,7 +1490,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstPeterSE : BibleBook
 	{
 		public FirstPeterSE() : base("FirstPeter", 60) { }
-		public override string Title => "1Peter";
+		public override string Title => "1 Peter";
 		public override string Abrv => "1Pe";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.GeneralEpistles;
 		public override BookEnum BookEnum => BookEnum.FirstPeter;
@@ -1510,7 +1512,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondPeterSE : BibleBook
 	{
 		public SecondPeterSE() : base("SecondPeter", 61) { }
-		public override string Title => "2Peter";
+		public override string Title => "2 Peter";
 		public override string Abrv => "2Pe";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.GeneralEpistles;
 		public override BookEnum BookEnum => BookEnum.SecondPeter;
@@ -1532,7 +1534,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class FirstJohnSE : BibleBook
 	{
 		public FirstJohnSE() : base("FirstJohn", 62) { }
-		public override string Title => "1John";
+		public override string Title => "1 John";
 		public override string Abrv => "1Jo";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.GeneralEpistles;
 		public override BookEnum BookEnum => BookEnum.FirstJohn;
@@ -1554,7 +1556,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class SecondJohnSE : BibleBook
 	{
 		public SecondJohnSE() : base("SecondJohn", 63) { }
-		public override string Title => "2John";
+		public override string Title => "2 John";
 		public override string Abrv => "2Jo";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.GeneralEpistles;
 		public override BookEnum BookEnum => BookEnum.SecondJohn;
@@ -1576,7 +1578,7 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	private sealed class ThirdJohnSE : BibleBook
 	{
 		public ThirdJohnSE() : base("ThirdJohn", 64) { }
-		public override string Title => "3John";
+		public override string Title => "3 John";
 		public override string Abrv => "3Jo";
 		public override BookGroupEnum BookGroupEnum => BookGroupEnum.GeneralEpistles;
 		public override BookEnum BookEnum => BookEnum.ThirdJohn;

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/ChapterButtons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/ChapterButtons.razor
@@ -1,19 +1,36 @@
 ﻿@using MyHebrewBible.Client.Enums
 
 
-@foreach (var r in ButtonRows)
+
+@if (ShowCloseButton)
 {
-	<div class="btn-group btn-group-sm">
-		@for (int i = r.ChapterStart; i <= r.ChapterEnd; i++)
-		{
-			int iLocal = i;
-			<button type="button" class="btn btn-outline-info font-monospace"
-							@onclick="@(e => ButtonClick(@iLocal))">
-				@((MarkupString)ButtonNumber(i))
+	<div class="card p-1 m-1">
+		<div class="card-header">
+			<h5>Chapters
+			<button type="button" class="mt-1 btn btn-danger btn-sm" @onclick="ButtonCloseClick">
+				<i class="fas fa-times"></i>
 			</button>
-		}
+			</h5>
+		</div>
+		<div class="card-body">
+			@foreach (var r in ButtonRows)
+			{
+				<div class="btn-group btn-group-sm">
+					@for (int i = r.ChapterStart; i <= r.ChapterEnd; i++)
+					{
+						int iLocal = i;
+						<button type="button" class="btn btn-outline-info font-monospace"
+										@onclick="@(e => ButtonClick(@iLocal))">
+							@((MarkupString)ButtonNumber(i))
+						</button>
+					}
+				</div>
+			}
+		</div>
 	</div>
 }
+
+
 
 @code {
 
@@ -21,8 +38,9 @@
 	[Parameter, EditorRequired] public int ButtonsPerRow { get; set; }
 	[Parameter] public EventCallback<BookAndChapter> OnChapterFilterSelected { get; set; }
 
-	public List<ButtonRow> ButtonRows { get; set; } = new List<ButtonRow>();
+	private bool ShowCloseButton;
 
+	public List<ButtonRow> ButtonRows { get; set; } = new List<ButtonRow>();
 
 	protected override void OnParametersSet()
 	{
@@ -30,8 +48,15 @@
 		PopulateButtonRows();
 	}
 
+	private void ButtonCloseClick()
+	{
+		ButtonRows.Clear();
+		ShowCloseButton = false;
+	}
+
 	private void PopulateButtonRows()
 	{
+		ShowCloseButton = true;
 		if (ButtonsPerRow >= CurrentBibleBook!.LastChapter)
 		{
 			// Add only one row
@@ -74,8 +99,10 @@
 
 	private void ButtonClick(int chapter)
 	{
-		ButtonRows.Clear();
+		//ButtonRows.Clear();
+		ShowCloseButton = false;
 		OnChapterFilterSelected.InvokeAsync(new BookAndChapter(CurrentBibleBook, chapter));
+		//StateHasChanged();  // this has no effect
 	}
 
 	protected MarkupString ButtonNumber(int i)

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Index.razor
@@ -8,8 +8,19 @@
 
 <PageTitle>Book Chapter</PageTitle>
 
+@* <p>@($"ShowSearch: {ShowSearch}")</p> *@
+
 <nav class="navbar navbar-light bg-light">
 	<div class="container-fluid">
+
+		@*
+		@if (ShowSearch)
+		{
+		}
+		else
+		{
+		}
+		*@
 
 		<div class="@MediaQuery.Xs.DivClass">
 			<TypeaheadEditForm BibleBook="@CurrentBibleBook" Chapter="@CurrentChapter"
@@ -37,32 +48,35 @@
 												 OnBookAndChapterSelected="@ReturnedBookAndChapter" />
 		</div>
 
+		@* <ShowHideSearchToggle ShowSearch="@ShowSearch" OnToggleSelected="ReturnedSearchToggle" /> *@
+
 	</div>
 </nav>
 
-<div class="pb-n1 mt-2 mb-2 border-bottom border-info">
-	<div class="d-flex justify-content-between mb-3">
-		<div class="ps-2">
-			@if (CurrentBookAndChapter is not null)
-			{
-				<PreviousButton PreviousBookAndChapter="@CurrentBookAndChapter" 
-					buttonToShow="ButtonsToShow.PreviousOnly" 
-					OnBookAndChapterSelected="@ReturnedBookAndChapter" />
-			}
+@* <p class="my-0">@($"ReturnedBookAndChapterString: {ReturnedBookAndChapterString}")</p> *@
+
+@if (CurrentBookAndChapter is not null)
+{
+	<div class="pb-n1 mt-2 mb-2 border-bottom border-info">
+		<div class="d-flex justify-content-between mb-3">
+			<div class="ps-2">
+				<PreviousButton PreviousBookAndChapter="@CurrentBookAndChapter"
+												buttonToShow="ButtonsToShow.PreviousOnly"
+												OnBookAndChapterSelected="@ReturnedBookAndChapter" />
+			</div>
+
+			<span class="text-center">@CurrentBookAndChapter.BibleBook!.Title @CurrentBookAndChapter.Chapter </span>
+
+			<div class="pe-2">
+				<NextButton NextBookAndChapter="@CurrentBookAndChapter"
+										buttonToShow="ButtonsToShow.NextOnly"
+										OnBookAndChapterSelected="@ReturnedBookAndChapter" />
+			</div>
 		</div>
-		<div class="pe-2">
-			@if (CurrentBookAndChapter is not null)
-			{
-				<NextButton  NextBookAndChapter="@CurrentBookAndChapter" 
-					buttonToShow="ButtonsToShow.NextOnly" 
-					OnBookAndChapterSelected="@ReturnedBookAndChapter"/>
-			}
-		</div>
+
 	</div>
+}
 
- @* <h5 class="text-center">Book Chapter</h5> *@
-
-</div>
 
 
 @if (verses == null)
@@ -81,20 +95,18 @@ else
 		else
 		{
 			<small>why for how come you know have a pin</small>
-		} *@
+		}
 
-		@*
 		@if (item.DescH != null)
 		{
 			<h3 class="mt-2">@item.DescH</h3>
 		}
-		*@
 
-		@* 		@if (item.DescD is not null)
+		@if (item.DescD is not null)
 		{
 			<h5 class="text-end mt-3 mb-1 text-black-50 fst-italic">@item.DescD</h5>
 		}
-*@
+		*@
 
 		<p class="fs-5">
 			<a title="@item.BCV" href="https://www.blueletterbible.org/kjv/gen/1/1/" target="_blank"><sup class="btn btn-outline-primary py-0 px-1"><b>@item.Verse</b></sup></a>  @((MarkupString)@item.KJV!)
@@ -110,6 +122,7 @@ else
 
 	protected override async Task OnInitializedAsync()
 	{
+
 		SetBibleBookAndChapter();
 		//SetSubTitle(null);
 		//ShowSearch = true;
@@ -126,13 +139,17 @@ else
 		if (GottenFromLocalStorage)
 		{
 			CurrentBibleBook = BibleBook.Genesis;
-			CurrentChapter = 2;
+			CurrentChapter = 1;
 			CurrentBookAndChapter = new BookAndChapter(CurrentBibleBook, CurrentChapter);
 		}
 		else
 		{
-			CurrentBibleBook = BibleBook.Genesis;
-			CurrentChapter = 2;
+
+			//CurrentBibleBook = BibleBook.Genesis;
+			//CurrentChapter = 1;
+			CurrentBibleBook = BibleBook.Exodus;
+			CurrentChapter = 40; // LastChapter is 40
+
 			CurrentBookAndChapter = new BookAndChapter(CurrentBibleBook, CurrentChapter);
 		}
 	}
@@ -163,28 +180,27 @@ else
 
 	private ICollection<BookChapter>? verses = null;
 
-	public BibleBook? PrevBibleBook { get; set; }
+	//public BibleBook? PrevBibleBook { get; set; } // Why am I saving this, it's assigned but it's not being referenced any where else
 
+	protected string? ReturnedBookAndChapterString;
 	private async Task ReturnedBookAndChapter(BookAndChapter bookAndChapter)
 	{
-		PrevBibleBook = CurrentBibleBook;
+		ReturnedBookAndChapterString = bookAndChapter.ToString();
+		//PrevBibleBook = CurrentBibleBook;
 		CurrentBibleBook = bookAndChapter.BibleBook;
 		CurrentChapter = bookAndChapter.Chapter;
-		CurrentBookAndChapter = new BookAndChapter(CurrentBibleBook, CurrentChapter);
 
+		//CurrentBookAndChapter = new BookAndChapter(CurrentBibleBook, CurrentChapter); // WHY am I ASSIGNING THIS TWICE ???
 		CurrentBookAndChapter = bookAndChapter!;
-		//long b = bookAndChapter.BibleBook!.Value;
-		//long c = bookAndChapter.Chapter;
+
+		//ShowSearch = false;
 		verses = await Api!.GetBookChapterAsync((long)bookAndChapter.BibleBook, (long)bookAndChapter.Chapter);
-		//verses = await Api!.GetBookChapterAsync(b, c);
 	}
 
-
-	//ToDo: review, not being used
-	// private bool ShowSearch;
-	// private void ReturnedSearchToggle(bool showSearch)
-	// {
-	// 	ShowSearch = showSearch;
-		// }
+	private bool ShowSearch;
+	private void ReturnedSearchToggle(bool showSearch)
+	{
+		ShowSearch = showSearch;
+	}
 
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/PrevNext/NextButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/PrevNext/NextButton.razor
@@ -1,11 +1,12 @@
 ﻿@using MyHebrewBible.Client.Enums
 
+
 @if (buttonToShow == ButtonsToShow.Both | buttonToShow == ButtonsToShow.NextOnly)
 {
 	@if (Next!.BibleBook is not null)
 	{
 		<button type="button" class="btn btn-outline-primary"
-						@onclick="@(e => ButtonClick(Next.BibleBook!))">
+						@onclick="ButtonClick">
 			<i class="@Enums.BibleBook.NavigationIcon.Next"></i>&nbsp;
 			<sup>@Next.ButtonText</sup>
 			@* <br /><small>Next</small> *@
@@ -16,22 +17,23 @@
 		<OnEdgeButton />
 	}
 }
+
 @code {
-	[Parameter, EditorRequired] public BookAndChapter? NextBookAndChapter { get; set; }
+	[Parameter, EditorRequired] public BookAndChapter? NextBookAndChapter { get; set; } 
 	[Parameter, EditorRequired] public ButtonsToShow buttonToShow { get; set; }
 	[Parameter] public EventCallback<BookAndChapter> OnBookAndChapterSelected { get; set; }
 
-	BibleBookPrevNext? Next;
+	BibleBookPrevNext? Next;  // only null when Rev 22:2
 
 	protected override void OnParametersSet()
 	{
-		//CurrentBookAndChapter = BookAndChapterParameter;
-		Next = NextBookAndChapter!.BibleBook!.NavigationNext(NextBookAndChapter.Chapter); // only null when Gen 1
+		Next = NextBookAndChapter!.BibleBook!.NavigationNext(NextBookAndChapter.Chapter);
 	}
 
-	private void ButtonClick(BibleBook bibleBook)
+	private void ButtonClick()
 	{
-		BookAndChapter? bookAndChapter = new BookAndChapter(bibleBook, NextBookAndChapter!.Chapter + 1);
+		BookAndChapter? bookAndChapter = new BookAndChapter(Next!.BibleBook, Next!.Chapter);
 		OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
 	}
+
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/PrevNext/PreviousButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/PrevNext/PreviousButton.razor
@@ -5,7 +5,7 @@
 	@if (Previous!.BibleBook is not null)
 	{
 		<button type="button" class="btn btn-outline-primary"
-						@onclick="@(e => ButtonClick( Previous.BibleBook!))">
+						@onclick="ButtonClick">
 			<sup>
 				@Previous.ButtonText &nbsp;
 			</sup><i class="@Enums.BibleBook.NavigationIcon.Previous"></i>
@@ -18,23 +18,21 @@
 	}
 }
 
-
 @code {
 	[Parameter, EditorRequired] public BookAndChapter? PreviousBookAndChapter { get; set; }
 	[Parameter, EditorRequired] public ButtonsToShow buttonToShow { get; set; }
 	[Parameter] public EventCallback<BookAndChapter> OnBookAndChapterSelected { get; set; }
 
-	BibleBookPrevNext? Previous;
+	BibleBookPrevNext? Previous; // only null when Gen 1
 
 	protected override void OnParametersSet()
 	{
-		//CurrentBookAndChapter = BookAndChapterParameter;
-		Previous = PreviousBookAndChapter!.BibleBook!.NavigationPrevious(PreviousBookAndChapter.Chapter); // only null when Gen 1
+		Previous = PreviousBookAndChapter!.BibleBook!.NavigationPrevious(PreviousBookAndChapter.Chapter); 
 	}
 
-	private void ButtonClick(BibleBook bibleBook)
+	private void ButtonClick()
 	{
-		BookAndChapter? bookAndChapter = new BookAndChapter(bibleBook, PreviousBookAndChapter!.Chapter - 1);
+		BookAndChapter? bookAndChapter = new BookAndChapter(Previous!.BibleBook, Previous!.Chapter);
 		OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
 	}
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Search/TypeaheadEditForm.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Search/TypeaheadEditForm.razor
@@ -4,10 +4,17 @@
 @using System.ComponentModel.DataAnnotations
 @using MyHebrewBible.Client.Enums
 
+@* 
+<p class="my-0">@($"ShowChapterButtons: {ShowChapterButtons}")</p>
+<p class="my-0">@($"SelectedBibleBookString: {SelectedBibleBookString}")</p>
+<p class="my-0">@($"ReturnedBookAndChapterFromChapterButtons: {ReturnedBookAndChapterFromChapterButtons}")</p>
+<p class="my-0">@($"Chapter: {Chapter}")</p> 
+*@
+
 @if (SelectedBibleBook != BibleBook.Psalms)
 {
 	<EditForm class="d-flex" Model="VM" OnValidSubmit="HandleFormSubmit">
-
+		<DataAnnotationsValidator />
 		<BlazoredTypeahead SearchMethod="SearchBibleBooks"
 											 @bind-Value="VM!.SelectedBook"
 											 EnableDropDown="true"
@@ -71,15 +78,20 @@ else
 	</EditForm>
 }
 
-@if (SelectedBibleBook != null)
+@if (ShowChapterButtons)
 {
-	@if (SelectedBibleBook != BibleBook.Psalms)
+	@if (SelectedBibleBook != null)
 	{
-		<div class="row pt-2 pb-1 d-print-none">
-			<div class="col-12">
-				<ChapterButtons CurrentBibleBook="@BibleBook" ButtonsPerRow="ButtonsPerRow" OnChapterFilterSelected="OnChapterSelected" />
+		@if (SelectedBibleBook != BibleBook.Psalms)
+		{
+			<div class="row pt-2 pb-1 d-print-none">
+				<div class="col-12">
+					<ChapterButtons CurrentBibleBook="@SelectedBibleBook"
+													ButtonsPerRow="ButtonsPerRow"
+													OnChapterFilterSelected="OnChapterSelected" />
+				</div>
 			</div>
-		</div>
+		}
 	}
 }
 
@@ -88,11 +100,16 @@ else
 	private TypeaheadVM? VM;
 	private TypeaheadAndChapterVM? VMPsalms;
 
+	// `BibleBook` and `Chapter`? Why not `BookAndChapter`
+	// I separated BibleBook and Chapter because Chapter isn't required
+	// and why is that?
 	[Parameter, EditorRequired] public BibleBook? BibleBook { get; set; }
-	[Parameter, EditorRequired] public MediaQuery? MediaQuery { get; set; }
 	[Parameter] public int Chapter { get; set; }
-
+	
+	[Parameter, EditorRequired] public MediaQuery? MediaQuery { get; set; }
 	[Parameter] public EventCallback<BookAndChapter> OnBookAndChapterSelected { get; set; }
+
+	protected bool ShowChapterButtons = true;
 
 	public int SelectedChapter { get; set; }
 	public BibleBook? SelectedBibleBook { get; set; }
@@ -116,10 +133,10 @@ else
 		VMPsalms = new TypeaheadAndChapterVM() { SelectedBook = BibleBook.Psalms, Chapter = Chapter };
 	}
 
-
 	protected string? ReturnedBookAndChapterFromChapterButtons;
 	private void OnChapterSelected(BookAndChapter bookAndChapter)
 	{
+		ShowChapterButtons = false;
 		ReturnedBookAndChapterFromChapterButtons = bookAndChapter.ToString();
 		OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
 	}
@@ -133,17 +150,17 @@ else
 
 	protected string? SelectedBibleBookString;
 
-	protected BookAndChapter? bookAndChapter;
 	private void HandleFormSubmit()
 	{
+		ShowChapterButtons = true;
 		SelectedBibleBook = VM!.SelectedBook;
 		SelectedBibleBookString = VM!.SelectedBook!.Name;
-		SelectedChapter = 1;
-		bookAndChapter = new BookAndChapter(VM!.SelectedBook, SelectedChapter);
-		OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
+		//SelectedChapter = 1;
+		SelectedChapter = Chapter;
 	}
 
 
+	protected BookAndChapter? bookAndChapter;
 	private void HandleValidSubmitPsalms()
 	{
 		SelectedBibleBook = VMPsalms!.SelectedBook;

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/ShowHideSearchToggle.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/ShowHideSearchToggle.razor
@@ -1,4 +1,6 @@
 ﻿
+@* ONLY USED BY 'Features\BookChapter\Index.razor' AND CURRENTLY COMMENTED OUT *@
+
 <button @onclick="ButtonClicked"
 				class="btn @Color btn-lg ">
 	@Title <i class='@Icon'></i>
@@ -10,7 +12,7 @@
 
 	//float-end
 	private string Color => ShowSearch ? "btn-outline-success" : "btn-outline-success";
-	private string Title => string.Empty; // ShowSearch ? "Hide " : "Search ";
+	private string Title => ShowSearch ? "Hide " : "Show "; //  string.Empty;
 	private string Icon => ShowSearch ? "fas fa-search-minus" : "fas fa-search-plus"; //"fas fa-chevron-up" : "fas fa-chevron-down";
 	
 	protected void ButtonClicked()


### PR DESCRIPTION


## `ChapterButtons`
Made this into a `card` with the close button in the `card-header`


## Fixed bug in `NextButton` and `PreviousButton`

- For Next, I was adding 1 to the chapter when I didn't need to
- For Previous I was subtracting 1 to the chapter when I didn't need to

I realized that the `OnParametersSet` method did all the work I needed i.e. I didn't need to mess with chapter.  I also realized that the `@onclick` could also be simplified.

```csharp
protected override void OnParametersSet()
{
  // use this for PreviousButton
  Previous = PreviousBookAndChapter!.BibleBook!.NavigationPrevious(PreviousBookAndChapter.Chapter); 

  // use this for NextButton
  Next = NextBookAndChapter!.BibleBook!.NavigationNext(NextBookAndChapter.Chapter); 
}
```

#### Before
```html
@onclick="@(e => ButtonClick(Next.BibleBook!))"
```

```csharp
private void ButtonClick(BibleBook bibleBook)
{
  BookAndChapter? bookAndChapter = new BookAndChapter(bibleBook, NextBookAndChapter!.Chapter + 1);
  OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
}
```

#### After
```html
@onclick="ButtonClick">
```

```csharp
private void ButtonClick()
{
  BookAndChapter? bookAndChapter = new BookAndChapter(Next!.BibleBook, Next!.Chapter);
  OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
}
```


## `HandleFormSubmit` Bug
- Features\BookChapter\Search\TypeaheadEditForm.razor
- Added `DataAnnotationsValidator` to `TypeaheadEditForm` which without it allowed `HandleFormSubmit` to fire even though nothing was chosen

```csharp
protected BookAndChapter? bookAndChapter;
private void HandleFormSubmit()
{
  if (VM!.SelectedBook is not null)  // this check is no longer necessary
  {
    ShowChapterButtons = true;
    SelectedBibleBook = VM!.SelectedBook;
    SelectedBibleBookString = VM!.SelectedBook!.Name;
    
    // Using Chapter makes more sense but it screws up the Prev Next button by not stopping at the Last chapter
    //SelectedChapter = Chapter;  
    SelectedChapter = 1;  
    
    // Why am I responding back to Index, this should only occur after `OnChapterSelected`
    bookAndChapter = new BookAndChapter(VM!.SelectedBook, SelectedChapter);
    OnBookAndChapterSelected.InvokeAsync(bookAndChapter);
  }
  else
  {
    SelectedBibleBookString = $"Inside {nameof(HandleFormSubmit)} yet VM!.SelectedBook IS NULL?"; 
    // won't happen because I added <DataAnnotationsValidator />
  }
}
