### PR TITLE
Fixed publish problems

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/MyHebrewBible.Client.csproj
+++ b/MyHebrewBible/MyHebrewBible.Client/MyHebrewBible.Client.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Blazored.Toast" Version="4.2.1" />
     <PackageReference Include="Blazored.Typeahead" Version="4.7.0" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MyHebrewBible/MyHebrewBible/.config/dotnet-tools.json
+++ b/MyHebrewBible/MyHebrewBible/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "8.0.8",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}


### PR DESCRIPTION

## Fixed publish problems

> Failed to find a valid digest in the 'integrity' attribute for resource 'https://myhebrewbible.azurewebsites.net/_framework/dotnet.native.wasm' with computed SHA-256 integrity 'zzzzzzzzzzzzzzzz='. The resource has been blocked.

The solution to this problem was found in the answer to this SO question.
- https://stackoverflow.com/questions/69926878/failed-to-find-a-valid-digest-in-the-integrity-attribute-for-resource-in-blazo/75347986#75347986

> deleting the bin and obj folders in the client project fixed it

## Updated Nuget Package
Microsoft.AspNetCore.Components.WebAssembly

I thought this might have solved my publish problem listed above but it didn't, oh well no biggy

## What Happened
my guess was that the problem was caused by downloading SDK for asp.net core 2.2
I need this to look at `MyHebrewBible_ConvertToCore` in VS so that I can convert code from it.


## This (`dotnet-tools.json`) got added, whatever that is
- C:\Source\repos\FastEndpoints\Mhb-FastEndpoints-Hosted-Blazor-Wasm\MyHebrewBible\MyHebrewBible\.config\dotnet-tools.json

```json
{
  "version": 1,
  "isRoot": true,
  "tools": {
    "dotnet-ef": {
      "version": "8.0.8",
      "commands": [
        "dotnet-ef"
      ],
      "rollForward": false
    }
  }
}
```