### PR TITLE
Parasha Grid returns selected Detail, also added MediaQuery

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Components/VerseParagraph.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Components/VerseParagraph.razor
@@ -9,11 +9,8 @@
 <LoadingComponent IsLoading="verses == null" TurnSpinnerOff="TurnSpinnerOff">
 	@foreach (var item in verses!)
 	{
-@* 		
-	
- *@
 		<p class="fs-5">
-			<a title="@item.BCV" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
+			<a title="@item.BCV [@item.ID]" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
 				<sup class="btn btn-outline-primary py-0 px-1">
 					<b>@item.Verse</b>
 				</sup>
@@ -28,26 +25,24 @@
 	[Parameter, EditorRequired] public VerseParagraphRange? VerseParagraphRange { get; set; }
 	[Parameter] public EventCallback<VerseSelected> OnVerseSelected { get; set; }
 
-	//protected long VerseRowCount;
-
 	private ICollection<BibleVerse>? verses = null;
 	protected bool TurnSpinnerOff = false;
 
-	protected override async Task OnInitializedAsync()
+	protected override async Task OnParametersSetAsync()
 	{
-		Logger!.LogInformation("{Class}!{Method}", nameof(VerseParagraph), nameof(OnInitializedAsync));
+		Logger!.LogInformation("{Class}!{Method}", nameof(VerseParagraph), nameof(OnParametersSetAsync));
 		try
 		{
-			await Task.Delay(500);  // ToDo: comment this out in production
-			if (VerseParagraphRange!.BegId >= VerseParagraphRange.EndId) throw new System.ApplicationException("BegId >= EndId");
-			if (VerseParagraphRange!.EndId - VerseParagraphRange.BegId > 300) throw new System.ApplicationException("Verse range can not exceed 300"); // ToDo: extract this
+			//await Task.Delay(200);  // ToDo: comment this out in production
+			if (VerseParagraphRange!.BegId >= VerseParagraphRange.EndId) 
+				throw new System.ApplicationException($"BegId [{VerseParagraphRange!.BegId}] >= EndId [{VerseParagraphRange!.EndId}]");
+			if (VerseParagraphRange!.EndId - VerseParagraphRange!.BegId > 300) throw new System.ApplicationException("Verse range can not exceed 300"); // ToDo: extract this
 			verses = await Api!.GetVerseListAsync(VerseParagraphRange.BegId, VerseParagraphRange.EndId);
-			//VerseRowCount = verses.Count;
 		}
 		catch (Exception ex)
 		{
-			Logger!.LogError(ex, "{Class}!{Method}", nameof(VerseParagraph), nameof(OnInitializedAsync));
-			Toast!.ShowError($"{Global.ToastShowError} {nameof(VerseParagraph)}!{nameof(OnInitialized)}");
+			Logger!.LogError(ex, "{Class}!{Method}", nameof(VerseParagraph), nameof(OnParametersSetAsync));
+			Toast!.ShowError($"{Global.ToastShowError} {nameof(VerseParagraph)}!{nameof(OnParametersSetAsync)}");
 		}
 		finally
 		{

--- a/MyHebrewBible/MyHebrewBible.Client/Components/VerseSections/SingleVerse.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Components/VerseSections/SingleVerse.razor
@@ -15,7 +15,7 @@ else
 		{
 			<p class="fs-5">
 
-				<a title="@item.BCV" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
+				<a title="@item.BCV [@item.ID]" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
 					<sup class="btn btn-outline-primary py-0 px-1">
 						<b>@item.Verse</b>
 					</sup>

--- a/MyHebrewBible/MyHebrewBible.Client/Constant.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Constant.cs
@@ -67,6 +67,7 @@ public static class DateFormat
 {
 	public const string ddd_mm_dd = "ddd, MM/dd";  //ddd, MM/dd/yyyy
 	public const string mm_dd = "MM/dd";
+	public const string MMM_d = "MMM d";
 	public const string MM_dd_HH_mm = "MM/dd HH:mm";
 	public const string MM_dd_hh_mm = "MM/dd hh:mm";
 	public const string dd = "dd";
@@ -86,3 +87,5 @@ public static class DateFormat
 //		public string AmountNoCents { get { return String.Format("{0:C0}", Amount); }	}
 //	*/
 //}
+
+// Ignore Spelling: YYYY  MMMM MMM dd ddd dddd HH

--- a/MyHebrewBible/MyHebrewBible.Client/Enums/TorahBookFilter.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/TorahBookFilter.cs
@@ -17,6 +17,7 @@ public abstract class TorahBookFilter : SmartEnum<TorahBookFilter>
 
 	#region Extra Fields
 	public abstract BibleBook BibleBook { get; }
+	public abstract string Abrv { get; }
 	#endregion
 
 	#region Private Instantiation
@@ -30,33 +31,38 @@ public abstract class TorahBookFilter : SmartEnum<TorahBookFilter>
 	{
 		public GenesisSE() : base(BibleBook.Genesis.Name, BibleBook.Genesis.Value) { }
 		public override BibleBook BibleBook => BibleBook.Genesis;
+		public override string Abrv =>  this.BibleBook.Abrv;
 	}
 
 	private sealed class ExodusSE : TorahBookFilter
 	{
 		public ExodusSE() : base(BibleBook.Exodus.Name, BibleBook.Exodus.Value) { }
 		public override BibleBook BibleBook => BibleBook.Exodus;
+		public override string Abrv =>  this.BibleBook.Abrv;
 	}
 
 	private sealed class LeviticusSE : TorahBookFilter
 	{
 		public LeviticusSE() : base(BibleBook.Leviticus.Name, BibleBook.Leviticus.Value) { }
 		public override BibleBook BibleBook => BibleBook.Leviticus;
+		public override string Abrv => this.BibleBook.Abrv;
 	}
 
 	private sealed class NumbersSE : TorahBookFilter
 	{
 		public NumbersSE() : base(BibleBook.Numbers.Name, BibleBook.Numbers.Value) { }
 		public override BibleBook BibleBook => BibleBook.Numbers;
+		public override string Abrv => this.BibleBook.Abrv;
 	}
 
 	private sealed class DeuteronomySE : TorahBookFilter
 	{
 		public DeuteronomySE() : base(BibleBook.Deuteronomy.Name, BibleBook.Deuteronomy.Value) { }
 		public override BibleBook BibleBook => BibleBook.Deuteronomy;
+		public override string Abrv => this.BibleBook.Abrv;
 	}
 	#endregion
 
 }
 
-
+// Ignore Spelling: Abrv

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Verses/ParagraphBottom.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Verses/ParagraphBottom.razor
@@ -5,7 +5,7 @@
 	@foreach (var item in BottomVerses)
 	{
 		<p class="fs-5">
-			<a title="@item.BCV" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
+			<a title="@item.BCV [@item.ID]" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
 				<sup class="btn btn-outline-primary py-0 px-1">
 					<b>@item.Verse</b>
 				</sup>

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Verses/ParagraphTop.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Verses/ParagraphTop.razor
@@ -6,7 +6,7 @@
 	{
 		<p class="fs-5">
 
-			<a title="@item.BCV" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
+			<a title="@item.BCV [@item.ID]" @onclick="@(e => ButtonClick(item.ID, item.Verse))">
 				<sup class="btn btn-outline-primary py-0 px-1">
 					<b>@item.Verse</b>
 				</sup>

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/DetailSection/Verses.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/DetailSection/Verses.razor
@@ -10,13 +10,14 @@
 
 				<div>
 					<h3 class="@VerseGroup!.HeaderColor"><b>@VerseGroup!.Title</b></h3>
-					<h6>@SubTitle</h6>
+					@* <h6>@SubTitle</h6> *@
+					@((MarkupString)SubTitle!)
 				</div>
 
 				<div>
 					<ShowHideToggle ToggleValue="ToggleValue"
-																		VerseGroup="VerseGroup"
-																		OnToggleSelected="ReturnedToggle" />
+													VerseGroup="VerseGroup"
+													OnToggleSelected="ReturnedToggle" />
 				</div>
 			</div>
 		</div>
@@ -32,11 +33,23 @@
 			}
 			else
 			{
-				@foreach (var item in HaftorahOrBritVersesList!)
+				if (VerseGroup == Enums.VerseGroup.Haftorah)
 				{
-					<div class="card-body">
-						<VerseParagraph VerseParagraphRange="item" />
-					</div>
+					@foreach (var item in HaftorahVersesList!)
+					{
+						<div class="card-body">
+							<VerseParagraph VerseParagraphRange="item" />
+						</div>
+					}
+				}
+				else
+				{
+					@foreach (var item in BritVersesList!)
+					{
+						<div class="card-body">
+							<VerseParagraph VerseParagraphRange="item" />
+						</div>
+					}
 				}
 			}
 		}
@@ -52,7 +65,8 @@
 	bool ToggleValue;
 
 	private VerseParagraphRange? TorahVerses;
-	private List<VerseParagraphRange>? HaftorahOrBritVersesList;
+	private List<VerseParagraphRange>? HaftorahVersesList;
+	private List<VerseParagraphRange>? BritVersesList;
 	private bool DataExists = false;
 
 	protected override async Task OnParametersSetAsync()
@@ -62,13 +76,21 @@
 		try
 		{
 			ToggleValue = await state!.Get(LocalStorage!);
+
 			if (VerseGroup == Enums.VerseGroup.Torah)
 			{
 				PopulateTorahVerses();
 			}
 			else
 			{
-				PopulateHaftorahOrBritVerses();
+				if (VerseGroup == Enums.VerseGroup.Haftorah)
+				{
+					PopulateHaftorahVerses();
+				}
+				else
+				{
+					PopulateBritVerses();
+				}
 			}
 		}
 		catch (Exception ex)
@@ -82,37 +104,46 @@
 	{
 		TorahVerses = new VerseParagraphRange(
 			CurrentReading!.TorahVerse.BegId, CurrentReading.TorahVerse.EndId
-			, CurrentReading.TorahVerse.BibleBook.Title + CurrentReading.TorahVerse.ChapterVerse);
-		
+			, CurrentReading.TorahVerse.BibleBook.Title + " " + CurrentReading.TorahVerse.ChapterVerse);
+
 		DataExists = true;
 	}
 
-	private void PopulateHaftorahOrBritVerses()
+	private void PopulateHaftorahVerses()
 	{
-		if (VerseGroup == Enums.VerseGroup.Haftorah)
+		if (CurrentReading!.HaftorahVerses is not null && CurrentReading!.HaftorahVerses.Any())
 		{
-			if (CurrentReading!.HaftorahVerses is not null && CurrentReading!.HaftorahVerses.Any())
+			HaftorahVersesList = new List<VerseParagraphRange>();
+			foreach (var item in CurrentReading.HaftorahVerses)
 			{
-				HaftorahOrBritVersesList = new List<VerseParagraphRange>();
-				foreach (var item in CurrentReading.HaftorahVerses)
-				{
-					HaftorahOrBritVersesList.Add(new VerseParagraphRange(item.BegId, item.EndId, item.BibleBook.Title + " " + item.ChapterVerse));
-				}
-				DataExists = true;
+				HaftorahVersesList.Add(new VerseParagraphRange(item.BegId, item.EndId, item.BibleBook.Title + " " + item.ChapterVerse));
 			}
+			DataExists = true;
 		}
 		else
 		{
-			if (CurrentReading!.BritVerses is not null && CurrentReading!.BritVerses.Any())
-			{
-				HaftorahOrBritVersesList = new List<VerseParagraphRange>();
-				foreach (var item in CurrentReading.BritVerses)
-				{
-					HaftorahOrBritVersesList.Add(new VerseParagraphRange(item.BegId, item.EndId, item.BibleBook.Title + " " + item.ChapterVerse));
-				}
-				DataExists = true;
-			}
+			HaftorahVersesList?.Clear();
+			//Toast!.ShowInfo($"Cleared Verses {nameof(PopulateHaftorahVerses)}");
 		}
+	}
+
+	private void PopulateBritVerses()
+	{
+		if (CurrentReading!.BritVerses is not null && CurrentReading!.BritVerses.Any())
+		{
+			BritVersesList = new List<VerseParagraphRange>();
+			foreach (var item in CurrentReading.BritVerses)
+			{
+				BritVersesList.Add(new VerseParagraphRange(item.BegId, item.EndId, item.BibleBook.Title + " " + item.ChapterVerse));
+			}
+			DataExists = true;
+		}
+		else
+		{
+			BritVersesList?.Clear();
+			//Toast!.ShowInfo($"Cleared Verses {nameof(PopulateBritVerses)}");
+		}
+
 	}
 
 	private void ReturnedToggle(ShowHideToggleVM vm)

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Constants.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Constants.cs
@@ -1,4 +1,15 @@
-﻿namespace MyHebrewBible.Client.Features.Parasha.Enums;
+﻿using Microsoft.AspNetCore.Components;
+
+namespace MyHebrewBible.Client.Features.Parasha.Enums;
+
+public static class ParashaFacts
+{
+	//public abstract BibleBookPrevNext NavigationPrevious(int Chapter);
+	//public abstract BibleBookPrevNext NavigationNext(int Chapter);
+
+	public const int FirstParashaId = 1;
+	public const int LastParashaId = 157;
+}
 
 public static class Constants
 {
@@ -18,6 +29,27 @@ public static class Constants
 		DateTimeOffset localTime = DateTimeOffset.Now;
 		TimeSpan utcOffset = localZone.GetUtcOffset(localTime);
 		return utcOffset;
+	}
+
+	public static MarkupString DaysFromOrToShabbat(DateTime dt)
+	{
+		TimeSpan timeSpan = dt - GetNextShabbatDate();
+		int days = timeSpan.Days;
+		if (days < 0)
+		{
+				return (MarkupString)$" <b>{Math.Abs(days)}</b> days <b class='text-danger'>before</b> next Shabbat";
+		}
+		else 
+		{
+			if (days > 0)
+			{
+				return (MarkupString)$" <b>{Math.Abs(days)}</b> days <b class='text-primary'>after</b> next Shabbat";
+			}
+			else 
+			{
+				return (MarkupString)$" today is Shabbat! <b class='text-success fs-5'>Shabbat Shalom!</b>";
+			}
+		}
 	}
 
 	// ToDo: probable need to remove `bool OverRideWithSaturday6PM` and `GetNextArizonaSaturday6PM` and write some unit tests

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Triennial.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Triennial.cs
@@ -1,4 +1,4 @@
-﻿// Ignore Spelling: Abrv Deu
+﻿// Ignore Spelling: Abrv Deu Tri
 
 using Ardalis.SmartEnum;
 using MyHebrewBible.Client.Enums;
@@ -373,30 +373,13 @@ public abstract class Triennial : SmartEnum<Triennial>
 		}
 	}
 
-	public string Torah  // Genesis 1:1-19
+	public string TorahPlusDaysFromOrToShabbat
 	{
 		get
 		{
-			return $" {BibleBook.FromValue(this.TorahVerse.BibleBook).Name} {this.TorahVerse.ChapterVerse}";
+			return $" {BibleBook.FromValue(this.TorahVerse.BibleBook).Name} {this.TorahVerse.ChapterVerse} {Enums.Constants.DaysFromOrToShabbat(this.Date).ToString()}";
 		}
 	}
-
-	public string Haftorah
-	{
-		get
-		{
-			return HaftorahVerses is not null ? String.Join(", ", HaftorahVerses.Select(s => s.BibleBook.Name + " " + s.ChapterVerse)) : "";
-		}
-	}
-
-	public string Brit
-	{
-		get
-		{
-			return BritVerses is not null ? String.Join(", ", BritVerses.Select(s => s.BibleBook.Name + " " + s.ChapterVerse)) : "";
-		}
-	}
-
 
 
 	public string TorahAbrv // Gen 1:1-19
@@ -406,6 +389,49 @@ public abstract class Triennial : SmartEnum<Triennial>
 			return $" {BibleBook.FromValue(this.TorahVerse.BibleBook).Abrv} {this.TorahVerse.ChapterVerse}";
 		}
 	}
+
+	public string TorahAbrvXsSm 
+	{
+		get
+		{
+			return $" {BibleBook.FromValue(this.TorahVerse.BibleBook).Abrv} {this.TorahVerse.ChapterVerse}";
+		}
+	}
+
+	public string Haftorah
+	{
+		get
+		{
+			return HaftorahVerses is not null ? String.Join(", ", HaftorahVerses.Select(s => s.BibleBook.Title + " " + s.ChapterVerse)) : ""; // s.BibleBook.Name
+		}
+	}
+
+	public string HaftorahAbrv
+	{
+		get
+		{
+			return HaftorahVerses is not null ? String.Join(", ", HaftorahVerses.Select(s => s.BibleBook.Abrv + " " + s.ChapterVerse)) : "";
+		}
+	}
+
+	public string Brit
+	{
+		get
+		{
+			return BritVerses is not null ? String.Join(", ", BritVerses.Select(s => s.BibleBook.Title + " " + s.ChapterVerse)) : ""; // s.BibleBook.Name
+		}
+	}
+
+
+	public string BritAbrv
+	{
+		get
+		{
+			return BritVerses is not null ? String.Join(", ", BritVerses.Select(s => s.BibleBook.Abrv + " " + s.ChapterVerse)) : "";
+		}
+	}
+
+
 
 	#endregion
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Index.razor
@@ -13,22 +13,33 @@
 
 @if (CurrentReading is not null)
 {
-	<HeaderOrGrid CurrentReading="CurrentReading" />
+
+	<div class="@MediaQuery.XsOrSm.DivClass">
+		<HeaderOrGrid CurrentReading="CurrentReading"
+									OnTriennialReadingSelected="ReturnedTriennialReadingId" MediaQuery="@MediaQuery.XsOrSm" />
+
+	</div>
+
+	<div class="@MediaQuery.MdOrLgOrXl.DivClass">
+		<HeaderOrGrid CurrentReading="CurrentReading"
+									OnTriennialReadingSelected="ReturnedTriennialReadingId" MediaQuery="@MediaQuery.MdOrLgOrXl" />
+
+	</div>
+	
+	<Verses CurrentReading="CurrentReading"
+					SubTitle="@CurrentReading!.TorahPlusDaysFromOrToShabbat"
+					LocalStorage="Enums.LocalStorage.Torah"
+					VerseGroup="Enums.VerseGroup.Torah" />
 
 	<Verses CurrentReading="CurrentReading"
-												SubTitle="@CurrentReading!.Torah"
-												LocalStorage="Enums.LocalStorage.Torah"
-												VerseGroup="Enums.VerseGroup.Torah" />
+					SubTitle="@CurrentReading!.Haftorah"
+					LocalStorage="Enums.LocalStorage.Haftorah"
+					VerseGroup="Enums.VerseGroup.Haftorah" />
 
 	<Verses CurrentReading="CurrentReading"
-												SubTitle="@CurrentReading!.Haftorah"
-												LocalStorage="Enums.LocalStorage.Haftorah"
-												VerseGroup="Enums.VerseGroup.Haftorah" />
-
-	<Verses CurrentReading="CurrentReading"
-												SubTitle="@CurrentReading!.Brit"
-												LocalStorage="Enums.LocalStorage.Brit"
-												VerseGroup="Enums.VerseGroup.Brit" />
+					SubTitle="@CurrentReading!.Brit"
+					LocalStorage="Enums.LocalStorage.Brit"
+					VerseGroup="Enums.VerseGroup.Brit" />
 }
 else
 {
@@ -36,24 +47,71 @@ else
 }
 
 @code {
+	//@($"{CurrentReading!.Torah} {CurrentReading!.DaysFromOrToShabbat})"
 	public Enums.Triennial? CurrentReading { get; set; }
+
 	protected string? PageTitle;
+	protected bool IsReadingCurrent;
 
 	protected override void OnInitialized()
 	{
-		CurrentReading = Enums.Triennial.List
-		.Where(w => w.Date == Enums.Constants.GetNextShabbatDate())  // .GetNextShabbatDate(OverRideWithSaturday6PM:true)) or .GetNextShabbatDate())
-		.SingleOrDefault();
+		CurrentReading = GetCurrentReading($"{nameof(Index)}!{nameof(OnInitialized)}");
+	}
 
-		if (CurrentReading is null)
+	private Enums.Triennial? GetCurrentReading(string calledBy)
+	{
+		Enums.Triennial? _reading =
+			Enums.Triennial.List
+			.Where(w => w.Date == Enums.Constants.GetNextShabbatDate())
+			.SingleOrDefault();
+
+		if (_reading is null)
 		{
-			Logger!.LogWarning("{Class}!{Method}; CurrentReading is null", nameof(Index), nameof(OnInitialized));
-			Toast!.ShowWarning($"Current reading is not found; inside {nameof(Index)}");
+			Logger!.LogWarning("{CalledBy}; _reading is null", calledBy);
+			Toast!.ShowWarning($"Current reading is not found; called by: {calledBy}");
+
+			//ToDo: maybe I should set it to a default e.g. Gen 1:1
+
+			PageTitle = "Parasha ?";
+
+			return null;
 		}
 		else
 		{
-			PageTitle = $"{CurrentReading.ParashaName} {CurrentReading.TorahAbrv}";
+			PageTitle = $"{_reading.ParashaName} {_reading.TorahAbrv}";
+			return _reading;
 		}
+
 	}
 
+	private void ReturnedTriennialReadingId(int id)
+	{
+		Enums.Triennial? _returnedReading = _returnedReading = Enums.Triennial.List.Where(w => w.Value == id).SingleOrDefault();
+		Enums.Triennial? _currentReading = GetCurrentReading($"{nameof(Index)}!{nameof(ReturnedTriennialReadingId)}, [id: {id}]");
+
+		if (_returnedReading is null)
+		{
+			Logger!.LogWarning("{Class}!{Method}; NonCurrentReading is null", nameof(Index), nameof(ReturnedTriennialReadingId));
+			Toast!.ShowWarning($"Requested reading [Id:{id}] is not found; inside {nameof(Index)}");
+		}
+		else
+		{
+			if (_currentReading is not null)
+			{
+				if (_returnedReading.Value != _currentReading.Value)
+				{
+					PageTitle = $"{_returnedReading.ParashaName} {_returnedReading.TorahAbrv}";
+					CurrentReading = _returnedReading;
+					Toast!.ShowSuccess($"Now viewing {CurrentReading.ParashaName} {CurrentReading.TorahAbrv}, see below or hide the grid to see the verses");
+				}
+				else
+				{
+					Toast!.ShowInfo($"Now viewing the Current Parasha Reading {_currentReading.ParashaName} {_currentReading.TorahAbrv}");
+				}
+				//StateHasChanged();
+			}
+		}
+
+
+	}
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/State/ParashaState.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/State/ParashaState.cs
@@ -60,10 +60,10 @@ public class ParashaState : IParashaState
 	{
 		try
 		{
-			Logger!.LogInformation("{Class}!{Method}"
-				, nameof(ParashaState), nameof(Update));
+			Logger!.LogInformation("{Class}!{Method}", nameof(ParashaState), nameof(Update));
 			await this.localStorage!.SetItemAsync(localStorage.Key, toggle);
 			NotifyStateHasChanged();
+			Logger!.LogInformation("{Class}!{Method}, localStorage: {localStorage}", nameof(ParashaState), nameof(Update), localStorage.Name);
 		}
 		catch (Exception ex)
 		{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/FilterButtons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/FilterButtons.razor
@@ -3,9 +3,19 @@
 <div class="d-flex justify-content-end mt-2">
 	@foreach (var item in TorahBookFilter.List.OrderBy(o => o.Value))
 	{
+
 		<button @onclick="@(() => OnButtonClicked(item))"
 						class="btn btn-outline-primary btn-sm @ActiveFilter(item)">
-			@item.Name &nbsp;<i class="fas fa-chevron-circle-right"></i>
+
+			@if (MediaQuery == MediaQuery.MdOrLgOrXl)
+			{
+				@item.Name <i class="fas fa-chevron-circle-right"></i>
+			}
+			else
+			{
+				@item.Abrv <i class="fas fa-chevron-circle-right"></i>
+			}
+
 		</button>
 	}
 	<div class="mt-1 ms-2"><i class="fas fa-filter"></i></div>
@@ -13,6 +23,7 @@
 
 @code {
 	[Parameter, EditorRequired] public required TorahBookFilter? CurrentFilter { get; set; }
+	[Parameter, EditorRequired] public MediaQuery? MediaQuery { get; set; }
 	[Parameter] public EventCallback<TorahBookFilter> OnFilterSelected { get; set; }
 
 	private TorahBookFilter? _SelectedFilter;

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/Grid.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/Grid.razor
@@ -5,34 +5,75 @@
 <div class="card border-info">
 
 	<div class="card-header">
-		<FilterButtons CurrentFilter="TorahBookFilter" OnFilterSelected="ReturnedFilter" />
+		<FilterButtons CurrentFilter="CurrentFilter"
+									 OnFilterSelected="ReturnedFilter"
+									 MediaQuery="@MediaQuery" />
 
 		<div class="d-flex justify-content-center mt-3">
 			<div class="pe-2 fs-4">
-				@TorahBookFilter!.Name
+				@CurrentFilter!.Name
 			</div>
 			<div class="pe-2 fs-4">
-				<i>@TorahBookFilter.BibleBook.TransliterationInHebrew</i>
+				<i>@CurrentFilter.BibleBook.TransliterationInHebrew</i>
 			</div>
 			<div class="pe-2">
-				<span class="hebrew">@TorahBookFilter.BibleBook.NameInHebrew</span>
+				<span class="hebrew">@CurrentFilter.BibleBook.NameInHebrew</span>
 			</div>
 		</div>
 	</div>
 
 	<QuickGrid Items="@filteredItems">
-		<PropertyColumn Property="@(p => p.TorahAbrv)" Title="Torah" />
-		<PropertyColumn Property="@(p => p.Date.ToString(DateFormat.YYYY_MM_DD))" Align="Align.Center" Title="Date" />
-		<PropertyColumn Property="@(p => p.ParashaName)" Sortable="false" Align="Align.Left" Title="Parasha Name" />
-		<PropertyColumn Property="@(p => p.Haftorah)" Sortable="false" Align="Align.Left" />
-		<PropertyColumn Property="@(p => p.Brit)" Sortable="false" Align="Align.Left" />
+
+		@if (MediaQuery == MediaQuery.MdOrLgOrXl)
+		{
+			<TemplateColumn Title="Torah">
+				<a @onclick="@(() => ButtonClicked(context.Value))" class="text-decoration-underline"
+					 title="Id: @context.Value @context.Date.ToString(DateFormat.YYYY_MM_DD)">
+					@context.TorahAbrv
+				</a>
+				@* <i class="fas fa-chevron-right"></i> *@
+			</TemplateColumn>
+		}
+		else
+		{
+			<TemplateColumn Title="Torah">
+				<button @onclick="@(() => ButtonClicked(context.Value))" 
+						class="btn btn-outline-info btn-sm"
+						title="Id: @context.Value @context.Date.ToString(DateFormat.YYYY_MM_DD)">
+					@context.TorahAbrvXsSm 
+				</button>
+				@* <i class="fas fa-chevron-right"></i> *@
+			</TemplateColumn>
+
+		}
+
+		<PropertyColumn Property="@(p => p.Date.ToString(@dateFormat))" Align="Align.Center" Title="Date" />
+
+		@if (MediaQuery == MediaQuery.MdOrLgOrXl)
+		{
+			<PropertyColumn Property="@(p => p.ParashaName)" Sortable="false" Align="Align.Left" Title="Parasha Name" />
+			<PropertyColumn Property="@(p => p.Meaning)" Sortable="false" Align="Align.Left" />
+			<PropertyColumn Property="@(p => p.Haftorah)" Sortable="false" Align="Align.Left" />
+			<PropertyColumn Property="@(p => p.Brit)" Sortable="false" Align="Align.Left" />
+		}
+		else
+		{
+			<TemplateColumn Title="Haftorah / Brit">
+				@context.HaftorahAbrv <br /> @context.BritAbrv
+			</TemplateColumn>
+		}
 	</QuickGrid>
 </div>
 
 @code {
 	[Parameter, EditorRequired] public TorahBookFilter? TorahBookFilter { get; set; }
+	[Parameter, EditorRequired] public MediaQuery? MediaQuery { get; set; }
+	[Parameter, EditorRequired] public EventCallback<int> OnTriennialReadingSelected { get; set; }
 
 	TorahBookFilter? CurrentFilter;
+
+	//private string dateFormat => (MediaQuery == MediaQuery.MdOrLgOrXl ? DateFormat.YYYY_MM_DD : DateFormat.MMM_d);  
+	private string dateFormat => DateFormat.MMM_d;
 
 	List<ParashaEnums.Triennial>? itemList;
 	IQueryable<ParashaEnums.Triennial>? items;
@@ -46,6 +87,13 @@
 		CurrentFilter = TorahBookFilter;
 		itemList = Enums.Triennial.List.ToList();
 		items = itemList.AsQueryable();
+	}
+
+	protected int TriennialReadingId;
+	private void ButtonClicked(int id)
+	{
+		TriennialReadingId = id;
+		OnTriennialReadingSelected.InvokeAsync(id);
 	}
 
 	private void ReturnedFilter(TorahBookFilter filter)

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/Header.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/Header.razor
@@ -1,12 +1,19 @@
-﻿@using MyHebrewBible.Client.Features.Parasha.Enums
+﻿@using GlobalEnums = MyHebrewBible.Client.Enums
+@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
 
 <div class="card">
 
 	<div class="card-body pb-0">
 		<div class="d-flex justify-content-start">
-			<div class="pe-3 text-center"><b>Next Shabbat</b><br /><b>@Constants.GetNextShabbatDate().ToString(DateFormat.YYYY_MM_DD)</b></div>
-			<div class="pe-3 text-center"><b>Name</b><br /><i>@CurrentReading!.ParashaName</i></div>
-			<div class="pe-3 text-center"><b>Meaning</b><br />@CurrentReading!.Meaning</div>
+			<div class="pe-3 text-center"><b>Torah</b><br /><b>@CurrentReading!.TorahAbrv</b></div>
+			<div class="pe-3 text-center"><b>Next Shabbat</b><br /><b>@ParashaEnums.Constants.GetNextShabbatDate().ToString(DateFormat.YYYY_MM_DD)</b></div>
+
+			@if (MediaQuery == GlobalEnums.MediaQuery.MdOrLgOrXl)
+			{
+				<div class="pe-3 text-center"><b>Name</b><br /><i>@CurrentReading!.ParashaName</i></div>
+				<div class="pe-3 text-center"><b>Meaning</b><br />@CurrentReading!.Meaning</div>
+			}
+
 			<div class="pe-3 text-center">
 				<b>Ahavta <i class="fas fa-external-link-square-alt"></i></b><br />
 				@CurrentReading!.AhavtaURL
@@ -15,11 +22,29 @@
 					<i class="fas fa-external-link-alt"></i>
 				</a>
 			</div>
+
+			<div class="pe-3 text-center">
+				<i class="fas fa-chevron-left"></i> Prev
+@* 				<button @onclick="@(() => ButtonClicked(context.Value))" 
+					class="btn btn-outline-info btn-sm"
+					 title="Id: @context.Value @context.Date.ToString(DateFormat.MMM_d)">
+				</button> *@
+			</div>
+
+			<div class="pe-3 text-center">
+				<i class="fas fa-chevron-right"></i> Next
+				@* 				<button @onclick="@(() => ButtonClicked(context.Value))"
+				class="btn btn-outline-info btn-sm"
+				title="Id: @context.Value @context.Date.ToString(DateFormat.MMM_d)">
+				</button> *@
+			</div>
+
 		</div>
 	</div>
 
 </div>
 
 @code {
-	[Parameter, EditorRequired] public Triennial? CurrentReading { get; set; }
+	[Parameter, EditorRequired] public ParashaEnums.Triennial? CurrentReading { get; set; }
+	[Parameter, EditorRequired] public GlobalEnums.MediaQuery? MediaQuery { get; set; }
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/HeaderOrGrid.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/TopSection/HeaderOrGrid.razor
@@ -4,8 +4,6 @@
 @inject IToastService? Toast
 @inject ILogger<HeaderOrGrid>? Logger
 
-@* @if (TorahBookFilter is not null){ } *@
-
 <div class="card border-primary mb-3">
 
 	<div class="card-header">
@@ -19,27 +17,50 @@
 		</div>
 	</div>
 
-	@if (ToggleValueShowGrid)
-	{
-		@if (TorahBookFilter is not null)
+	<div class="@MediaQuery.XsOrSm.DivClass">
+		@if (ToggleValueShowGrid)
 		{
-		<Grid TorahBookFilter="TorahBookFilter" />
+			@if (TorahBookFilter is not null)
+			{
+				<Grid TorahBookFilter="TorahBookFilter"
+					 MediaQuery="@MediaQuery.XsOrSm"
+							OnTriennialReadingSelected="ReturnedTriennialReadingId" />
+			}
 		}
-	}
-	else
-	{
-		<Header CurrentReading="CurrentReading" />
-	}
-</div>
+		else
+		{
+			<Header CurrentReading="CurrentReading" MediaQuery="@MediaQuery.XsOrSm" />
+		}
 
+	</div>
+
+	<div class="@MediaQuery.MdOrLgOrXl.DivClass">
+		@if (ToggleValueShowGrid)
+		{
+			@if (TorahBookFilter is not null)
+			{
+				<Grid TorahBookFilter="TorahBookFilter"
+							MediaQuery="@MediaQuery.MdOrLgOrXl"
+							OnTriennialReadingSelected="ReturnedTriennialReadingId" />
+			}
+		}
+		else
+		{
+			<Header CurrentReading="CurrentReading" MediaQuery="@MediaQuery.MdOrLgOrXl" />
+		}
+
+	</div>
+
+</div>
 
 
 @code {
 	[Parameter, EditorRequired] public Enums.Triennial? CurrentReading { get; set; }
+	[Parameter, EditorRequired] public MediaQuery? MediaQuery { get; set; }
+	[Parameter, EditorRequired] public EventCallback<int> OnTriennialReadingSelected { get; set; }
 
 	TorahBookFilter? TorahBookFilter;
 	bool ToggleValueShowGrid;
-
 
 	protected override async Task OnParametersSetAsync()
 	{
@@ -61,4 +82,12 @@
 		state!.Update(headerToggle, Enums.LocalStorage.Grid);
 		ToggleValueShowGrid = headerToggle;
 	}
+
+	private void ReturnedTriennialReadingId(int id)
+	{
+		ToggleValueShowGrid = false;
+		state!.Update(false, Enums.LocalStorage.Grid);
+		OnTriennialReadingSelected.InvokeAsync(id);
+	}
+
 }

--- a/MyHebrewBible/MyHebrewBible.Client/HealthChecks/Parasha/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/HealthChecks/Parasha/Index.razor
@@ -1,0 +1,116 @@
+﻿@page "/HealthChecks/Parasha"
+
+@using Microsoft.AspNetCore.Components.QuickGrid
+@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
+@using MyHebrewBible.Client.Features.Parasha
+
+<div class="card mb-3 border-warning">
+	<div class="card-header">
+		<h4 class="card-title text-center"><code>HaftorahVerses is null</code></h4>
+	</div>
+	<div class="card-body">
+		<TableTemplate Items="ParashaEnums.Triennial.List.Where(w => w.HaftorahVerses is null).OrderBy(o => o.Value).ToList()">
+			<TableHeader>
+				<th class="text-info">Id</th>
+				<th class="text-primary">Name</th>
+				<th class="text-danger">Haftorah</th>
+			</TableHeader>
+			<RowTemplate>
+				<td>@context.Value</td>
+				<td>@context.Name</td>
+				<td></td>
+			</RowTemplate>
+		</TableTemplate>
+	</div>
+	
+</div>
+
+<div class="card mb-3 border-warning">
+	<div class="card-header">
+		<h4 class="card-title text-center"><code>BritVerses is null</code></h4>
+	</div>
+	<div class="card-body">
+		<TableTemplate Items="ParashaEnums.Triennial.List.Where(w => w.BritVerses is null).OrderBy(o => o.Value).ToList()">
+			<TableHeader>
+				<th class="text-info">Id</th>
+				<th class="text-primary">Name</th>
+				<th class="text-danger">BritVerses</th>
+			</TableHeader>
+			<RowTemplate>
+				<td>@context.Value</td>
+				<td>@context.Name</td>
+				<td>
+				</td>
+			</RowTemplate>
+		</TableTemplate>
+	</div>
+</div>
+
+
+<div class="card mb-3 border-warning">
+	<div class="card-header">
+		<h4 class="card-title text-center"><code>HaftorahVerses is not null</code></h4>
+	</div>
+	<div class="card-body">
+		<TableTemplate Items="ParashaEnums.Triennial.List.Where(w => w.HaftorahVerses is not null).OrderBy(o => o.Value).ToList()">
+			<TableHeader>
+				<th class="text-info">Id</th>
+				<th class="text-primary">Name</th>
+				<th class="text-danger">Haftorah</th>
+			</TableHeader>
+			<RowTemplate>
+				<td>@context.Value</td>
+				<td>@context.Name</td>
+				<td>
+					@foreach (var item in @context.HaftorahVerses!)
+					{
+						if (item.BegId > item.EndId)
+						{
+							<span>@item.BibleBook.Title @item.ChapterVerse</span> <br />
+							<span>@item.BegId; @item.EndId</span>
+						}
+					    
+					}
+				</td>
+			</RowTemplate>
+		</TableTemplate>
+	</div>
+	@* <p class="card-footer text-center"><code><small>BibleBook.List.Count</small></code>: @BibleBook.List.Count</p> *@
+</div>
+
+
+
+<div class="card mb-3 border-warning">
+	<div class="card-header">
+		<h4 class="card-title text-center"><code>BritVerses is not null</code></h4>
+	</div>
+	<div class="card-body">
+		<TableTemplate Items="ParashaEnums.Triennial.List.Where(w => w.BritVerses is not null).OrderBy(o => o.Value).ToList()">
+			<TableHeader>
+				<th class="text-info">Id</th>
+				<th class="text-primary">Name</th>
+				<th class="text-danger">BritVerses</th>
+			</TableHeader>
+			<RowTemplate>
+				<td>@context.Value</td>
+				<td>@context.Name</td>
+				<td>
+					@foreach (var item in @context.BritVerses!)
+					{
+						if (item.BegId > item.EndId)
+						{
+							<span>@item.BibleBook.Title @item.ChapterVerse</span> <br />
+							<span>@item.BegId; @item.EndId</span>
+						}
+					}
+				</td>
+			</RowTemplate>
+		</TableTemplate>
+	</div>
+</div>
+
+
+
+@code {
+
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Layout/MainLayout.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Layout/MainLayout.razor
@@ -9,7 +9,7 @@
 			<li class="list-inline-item"><a class="" href="/bookchapter">Book Chapter</a></li>
 			<li class="list-inline-item"><a class="" href="/VerseList">VL</a></li>
 			<li class="list-inline-item"><a class="" href="/donate">Donate</a></li>
-
+			@* <li class="list-inline-item"><a class="" href="/HealthChecks/Parasha" title="Parasha Haftorah and Brit VerseList ">PVL</a></li> *@
 			<li class="list-inline-item"><a class="" href="/hebrew">Hebrew</a></li>
 		</ul>
 	</div>

--- a/MyHebrewBible/MyHebrewBible.Client/MyHebrewBible.Client.csproj
+++ b/MyHebrewBible/MyHebrewBible.Client/MyHebrewBible.Client.csproj
@@ -24,4 +24,8 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Features\Parasha\PrevNext\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# Commit | branch: 025-more-parasha-stuff

1. [x] Fix verses so the can be drilled down to
2. [x] <strike>Make a template of Haftorah and Brit; made instead components under `DetailSection` 📁 </strike>
3. [x] Fix Current Shabbat date, it's to early</strike>
4. [x] Make the Parasha look good on phone
5. [x] <strike>rename SmartEnum<Ahavta> to SmartEnum<Triennial></strike>
6. [x] <strike>rename CurrentAhavta to CurrentReading</strike>
7. [x] <strike>Add a filter to Grid</strike>
8. [x] Add a link in the Grid so that it will show up in the Detail section
9. [ ] Leverage <App> so that it will close the Grid when a reading is selected. 
10. [ ] Add a database project MyHebrewBibleParashaCodeGen
11. [ ] Make the codegen process pick up the new name and add the Ahavta links
12. [x] <strike>Create a ParashaState.</strike>
    1.  [x] <strike>Added State subfolder under the Features/Parasha folder</strike>
    2.  [x] <strike>Added `ServiceCollectionExtensions.cs` and had Program.cs reference that</strike>
    3.  [x] <strike>`ParashaState` uses the `async` version of Blazored LocalStorage</strike>
    4.  [x] <strike>Created a `SmartEnum<LocalStorage>` so that I can pass the key value</strike>
13. [ ] Some of the dates are wrong, e.g. Gen 2:4-25; Isa 42:5
14. [ ] Check that the BegId is NOT >= EndId; see `VerseParagraph` 
15. [ ] Validate the Parasha readings with the ones LMM is using
16. [ ] Remove the duplicate <Sections> in BookChapter/Verses and use the one in Components/VerseSections
17. [x] Bug in Parasha, the return from the Grid does not clear the Haftorah and Brit verses
18. [ ] Add Prev/Next to Parasha



## Components/
`VerseParagraph` I was given an error

### Bug Fix
- The Haftorah and Brit verses were not being refreshed because that logic was in the `OnInitializedAsync` method and needed to be in the `OnParametersSetAsync` method


## Features/Parasha/

### DetailsSection/`Verses` 
1. Split out the `HaftorahOrBritVersesList` into two separate lists. 
I thought this was the solution to Bug #17, but (I think) that's not the case
Anyway I left this logic in there but could probably be put back the way it was.

2. Added a `@((MarkupString)SubTitle!)` for subtitle


### TopSection/ 

Added #8 feature i.e. an anchor/button to the detail section

```csharp
[Parameter, EditorRequired] public EventCallback<int> OnTriennialReadingSelected { get; set; }

protected int TriennialReadingId;
private void ButtonClicked(int id)
{
    TriennialReadingId = id;
    OnTriennialReadingSelected.InvokeAsync(id);
}

```

#### `HeaderOrGrid`
A added a pass through for the for feature #8 that's because `HeaderOrGrid` sits between `Index` and `Grid`


```html
<Grid TorahBookFilter="TorahBookFilter"
        MediaQuery="@MediaQuery.XsOrSm"
        OnTriennialReadingSelected="ReturnedTriennialReadingId" />
}
```

```csharp
[Parameter, EditorRequired] public EventCallback<int> OnTriennialReadingSelected { get; set; }


private void ReturnedTriennialReadingId(int id)
{
    ToggleValueShowGrid = false;
    state!.Update(false, Enums.LocalStorage.Grid);
    OnTriennialReadingSelected.InvokeAsync(id);
}

```

#### MediaQuery
- Added to `Index`,  `FilterButtons` and `Grid`
