### PR TITLE
Parasha Prev/Next + URL working

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Components/PageHeader.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Components/PageHeader.razor
@@ -28,24 +28,6 @@
 
 	<div class="collapse navbar-collapse justify-content-end">
 
-		@if (PageEnum == Nav.Parasha)
-		{
-		<div class="ps-1">
-				<a class="btn btn-primary" title="@Nav.ParashaList.Title" href="@Nav.ParashaList.Index">
-				<i class="@Nav.ParashaList.Icon"></i>
-			</a>
-		</div>
-		}
-
-		@if (PageEnum == Nav.ParashaList)
-		{
-			<div class="ps-1">
-				<a class="btn btn-primary" title="@Nav.Parasha.Title" href="@Nav.Parasha.Index">
-					<i class="@Nav.Parasha.Icon"></i>
-				</a>
-			</div>
-		}
-
 		<div class="ps-1">
 			<a class="btn btn-primary" title="Configuration" href="">
 				<i class="fas fa-cog"></i>
@@ -62,6 +44,7 @@
 
 @code {
 	[Parameter, EditorRequired] public Nav PageEnum { get; set; } = Nav.Home;
-	[Parameter]	public string? BorderCSS { get; set; } = "border-bottom border-info";
+	[Parameter] public string? BorderCSS { get; set; } = "border-bottom border-info";
 	[Parameter] public string? PageTitle { get; set; }
+
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/bookchapter/{BookId:int}/{Chapter:int}/{slug?}"
+﻿@page "/bookchapter/{BookId:int}/{Chapter:int}/{Slug}"
 
 @using MyHebrewBible.Client.State
 @using MyHebrewBible.Client.Layout
@@ -47,7 +47,7 @@
 
 	[Parameter, EditorRequired] public int BookId { get; set; }
 	[Parameter, EditorRequired] public int Chapter { get; set; }
-	[Parameter] public string? Slug { get; set; }
+	[Parameter] public string? Slug { get; set; } 
 
 	public BookAndChapter? CurrentBookAndChapter { get; set; }
 
@@ -77,6 +77,7 @@
 
 		await CascadingAppState!.AppState!.BookChapterState!.Update(rec);
 		CurrentBookAndChapter = bookAndChapter!;
+		PageTitle = GlobalEnums.BibleBookFormat.BC(bookAndChapter);
 	}
 
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Home/FancyFatNavButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Home/FancyFatNavButton.razor
@@ -1,5 +1,6 @@
 ﻿@using MyHebrewBible.Client.Enums
 @using MyHebrewBible.Client.State
+@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
 
 @inject NavigationManager NavigationManager
 
@@ -23,13 +24,13 @@
 	protected string IconSize => $"{(MediaQuery == MediaQuery.Sm ? " fa-2x" : " fa-3x")}";
 	protected string FontSize => $"{(MediaQuery == MediaQuery.Sm ? " fs-5" : " fs-4")}";
 
-	
+
 	private void ButtonClicked(int id)
 	{
-		// ToDo: this is a hack but it works. thinking I need to move much of this code to `Client.Enums.Nav`
-		// ToDo: do something similar with Parasha and probable VerseList
+
 		if (Nav.FromValue(id) == Nav.BookChapter)
 		{
+			// ToDo: this is a hack but it works. thinking I need to move much of this code to `Client.Enums.Nav`
 			BibleBookIdAndChapter? rec = CascadingAppState!.AppState!.BookChapterState!.Get();
 			if (rec is not null)
 			{
@@ -43,8 +44,15 @@
 		}
 		else
 		{
-			NavigationManager!.NavigateTo(Nav.FromValue(id) + "/");
+			if (Nav.FromValue(id) == Nav.Parasha)
+			{
+				NavigationManager!.NavigateTo(ParashaEnums.Constants.GetUrl() ?? "");
+			}
+			else
+			{
+				NavigationManager!.NavigateTo(Nav.FromValue(id) + "/");
+			}
 		}
-		
+
 	}
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Constants.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Constants.cs
@@ -1,18 +1,47 @@
 ﻿using Microsoft.AspNetCore.Components;
+using MyHebrewBible.Client.Enums;
 
 namespace MyHebrewBible.Client.Features.Parasha.Enums;
 
 public static class ParashaFacts
 {
-	//public abstract BibleBookPrevNext NavigationPrevious(int Chapter);
-	//public abstract BibleBookPrevNext NavigationNext(int Chapter);
-
-	public const int FirstParashaId = 1;
+	public const int FirstParashaId = 1; 
 	public const int LastParashaId = 157;
 }
 
 public static class Constants
 {
+
+	public static string PrevNextUrl(Triennial triennial) 
+	{
+		return $"parasha/{triennial.Value}/{BibleBook.FromValue(triennial.TorahVerse.BibleBook).Abrv}_{triennial.TorahVerse.ChapterVerse.Replace("-", "-to-").Replace(":", "-")}";
+	}
+
+	public static string? GetUrl()
+	{
+		string? url = null; 
+
+		Triennial? _reading =
+			Triennial.List
+			.Where(w => w.Date == Constants.GetNextShabbatDate())
+			.SingleOrDefault();
+
+		if (_reading is not null)
+		{
+			url = _reading.Url;
+		}
+		else
+		{
+			Triennial? _defaultReading = Triennial.List.FirstOrDefault();
+			if (_defaultReading is not null)
+			{
+				url = _defaultReading.Url;
+			}
+			//else {//ToDo: Throw Exception?	}
+		}
+
+		return url;
+	}
 
 	public static string CurrentReadDateTextFormat(DateTime readDate)
 	{
@@ -52,15 +81,15 @@ public static class Constants
 		int days = timeSpan.Days;
 		if (days < 0)
 		{
-				return (MarkupString)$" <b>{Math.Abs(days)}</b> days <b class='text-danger'>before</b> next Shabbat";
+			return (MarkupString)$" <b>{Math.Abs(days)}</b> days <b class='text-danger'>before</b> next Shabbat";
 		}
-		else 
+		else
 		{
 			if (days > 0)
 			{
 				return (MarkupString)$" <b>{Math.Abs(days)}</b> days <b class='text-primary'>after</b> next Shabbat";
 			}
-			else 
+			else
 			{
 				return (MarkupString)$" today is Shabbat! <b class='text-success fs-5'>Shabbat Shalom!</b>";
 			}
@@ -128,5 +157,5 @@ public static class Constants
 		DateTime nextSundayAt1AM = nextSunday.AddHours(1);
 		return nextSundayAt1AM;
 	}
-	
+
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Triennial.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/Triennial.cs
@@ -2,6 +2,7 @@
 
 using Ardalis.SmartEnum;
 using MyHebrewBible.Client.Enums;
+using MyHebrewBible.Client.Features.Parasha.Toolbar;
 
 namespace MyHebrewBible.Client.Features.Parasha.Enums;
 
@@ -186,7 +187,7 @@ public abstract class Triennial : SmartEnum<Triennial>
 	/**/
 	public static readonly Triennial Gen_01a = new Gen_01aSE();
 	public static readonly Triennial Gen_01b = new Gen_01bSE();
-	
+
 	//public static readonly Triennial Gen_01b = new Gen_01SE();
 
 	public static readonly Triennial Gen_02 = new Gen_02SE();
@@ -367,7 +368,54 @@ public abstract class Triennial : SmartEnum<Triennial>
 	public abstract List<VerseRange>? HaftorahVerses { get; }
 	public abstract List<VerseRange>? BritVerses { get; }
 
-	//Methods
+	//Properties
+
+	public bool HasPrevious => this.Value > ParashaFacts.FirstParashaId ? true : false;
+	public bool HasNext => this.Value < ParashaFacts.LastParashaId ? true : false;
+
+	public PrevNextVM? PreviousVM
+	{
+		get
+		{
+			if (HasPrevious)
+			{
+				Triennial _prev = Triennial.FromValue(this.Value - 1);
+				return new PrevNextVM(_prev, Constants.PrevNextUrl(_prev), "fas fa-arrow-left");
+			}
+			else
+			{
+				return null;
+			}
+		}
+	}
+
+	public PrevNextVM? NextVM
+	{
+		get
+		{
+			if (HasNext)
+			{
+				Triennial _next = Triennial.FromValue(this.Value + 1);
+				return new PrevNextVM(_next, Constants.PrevNextUrl(_next), "fas fa-arrow-right");
+			}
+			else
+			{
+				return null;
+			}
+		}
+	}
+
+
+	public string Url 
+	{
+		get
+		{
+			string slug = $"{BibleBook.FromValue(this.TorahVerse.BibleBook).Abrv}_{this.TorahVerse.ChapterVerse.Replace("-", "-to-").Replace(":", "-")}";
+			return ($"parasha/{this.Value}/{slug}");
+		}
+	}
+
+
 	public DateTime Date
 	{
 		get
@@ -375,6 +423,7 @@ public abstract class Triennial : SmartEnum<Triennial>
 			return Constants.TriennialSeedDate.AddDays(7 * (this.Value - 1));
 		}
 	}
+
 	public string Title // 1.1, Gen 1:1-19, Sep 29 2018; 
 	{
 		get
@@ -448,7 +497,7 @@ public abstract class Triennial : SmartEnum<Triennial>
 
 
 	#region Private Instantiation
-	
+
 	private sealed class Gen_01aSE : Triennial
 	{
 		public Gen_01aSE() : base($"{nameof(Id.Gen_01a)}", Id.Gen_01a) { }
@@ -480,7 +529,7 @@ public abstract class Triennial : SmartEnum<Triennial>
 		public override List<VerseRange>? HaftorahVerses => null;
 		public override List<VerseRange>? BritVerses => null;
 	}
-	
+
 	/*
 	private sealed class Gen_01SE : Triennial
 	{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Header.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Header.razor
@@ -1,7 +1,7 @@
 ﻿@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
 
 	<div class="card-body pb-0">
-		<div class="d-flex justify-content-start">
+		<div class="d-flex justify-content-center">
 			<div class="pe-3 text-center"><b>Torah</b><br /><b>@CurrentReading!.TorahAbrv</b></div>
 			<div class="pe-3 text-center"><b>Next Shabbat</b><br /><b>@ParashaEnums.Constants.GetNextShabbatDate().ToString(DateFormat.YYYY_MM_DD)</b></div>
 
@@ -18,16 +18,6 @@
 					<i class="fas fa-external-link-alt"></i>
 				</a>
 			</div>
-
-		@* ToDo: These could be moved to the Navbar 
-			<div class="pe-3 text-center">
-				<i class="fas fa-chevron-left"></i> Prev
-			</div>
-
-			<div class="pe-3 text-center">
-				<i class="fas fa-chevron-right"></i> Next
-			</div>
-		*@
 
 		</div>
 	</div>

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Index.razor
@@ -1,31 +1,37 @@
-﻿@page "/Parasha"
-
+﻿@page "/Parasha/{Id:int}/{Slug}"
 @using MyHebrewBible.Client.Enums
-@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
+
+@using MyHebrewBible.Client.Features.Parasha.Enums
+@using MyHebrewBible.Client.Features.Parasha.Toolbar
 
 @inject ILogger<Index>? Logger
 @inject IToastService? Toast
 
-<PageHeader PageEnum="@MyHebrewBible.Client.Enums.Nav.Parasha" BorderCSS="" />
+<PageTitle>@Nav.Parasha.Title @PageTitleDetail</PageTitle>
+
+<Buttons CurrentReading="CurrentReading"  OnTriennialSelected="ReturnedTriennial" /> 
 
 @if (CurrentReading is not null)
 {
-	<div class="card border-primary mb-3">
+	<br />
+	<div class="card border-primary mb-3 mt-5">
+@* 		
 		<div class="card-header">
 			<h2>Current Parasha</h2>
 		</div>
-
-		<div class="@MediaQuery.XsOrSm.DivClass">
-			<Header CurrentReading="CurrentReading" MediaQuery="@MediaQuery.XsOrSm" />
+ *@
+		<div class="@GlobalEnums.MediaQuery.XsOrSm.DivClass">
+			<Header CurrentReading="CurrentReading" MediaQuery="@GlobalEnums.MediaQuery.XsOrSm" />
 		</div>
 
-		<div class="@MediaQuery.MdOrLgOrXl.DivClass">
-			<Header CurrentReading="CurrentReading" MediaQuery="@MediaQuery.MdOrLgOrXl" />
+		<div class="@GlobalEnums.MediaQuery.MdOrLgOrXl.DivClass">
+
+			<Header CurrentReading="CurrentReading" MediaQuery="@GlobalEnums.MediaQuery.MdOrLgOrXl" />
 		</div>
 
 	</div>
 
-	@foreach (var item in ParashaEnums.ShowSection.List.OrderBy(o => o.Value))
+	@foreach (var item in ShowSection.List.OrderBy(o => o.Value))
 	{
 		<div class="card bg-light mb-3">
 			<div class="card-header">
@@ -42,17 +48,17 @@
 					</div>
 				</div>
 
-				@if (CurrentPermutations.HasFlag(ParashaEnums.Permutation.Torah) && item == ParashaEnums.ShowSection.Torah)
+				@if (CurrentPermutations.HasFlag(Permutation.Torah) && item == ShowSection.Torah)
 				{
 					<TorahVerses CurrentReading="CurrentReading" />
 				}
 
-				@if (CurrentPermutations.HasFlag(ParashaEnums.Permutation.Haftorah) && item == ParashaEnums.ShowSection.Haftorah)
+				@if (CurrentPermutations.HasFlag(Permutation.Haftorah) && item == ShowSection.Haftorah)
 				{
 					<HaftorahVerses CurrentReading="CurrentReading" />
 				}
 
-				@if (CurrentPermutations.HasFlag(ParashaEnums.Permutation.Brit) && item == ParashaEnums.ShowSection.Brit)
+				@if (CurrentPermutations.HasFlag(Permutation.Brit) && item == ShowSection.Brit)
 				{
 					<BritVerses CurrentReading="CurrentReading" />
 				}
@@ -68,30 +74,34 @@ else
 }
 
 @code {
-	public ParashaEnums.Triennial? CurrentReading { get; set; }
+	[Parameter, EditorRequired] public int Id { get; set; }
+	[Parameter] public string? Slug { get; set; } // not used
 
 	[CascadingParameter] public CascadingAppState? CascadingAppState { get; set; }
-	protected ParashaEnums.Permutation CurrentPermutations;
+	protected Permutation CurrentPermutations;
+
+	public Triennial? CurrentReading { get; set; }
+
+	private string? PageTitleDetail = string.Empty;
 
 	protected override void OnInitialized()
 	{
-		CurrentReading = GetCurrentReading($"{nameof(Index)}!{nameof(OnInitialized)}");
+		Logger!.LogInformation("{Method}, Id: {Id}", nameof(OnInitialized), Id);
+		CurrentReading = GetCurrentReadingViaRoutes(Id);
+
+		if (CurrentReading is not null) {	PageTitleDetail = CurrentReading.TorahAbrv;	}
+
 		CurrentPermutations = GetCurrentPermutation();
 	}
 
-	private ParashaEnums.Triennial? GetCurrentReading(string calledBy)
+	private Triennial? GetCurrentReadingViaRoutes(int id)
 	{
-		ParashaEnums.Triennial? _reading =
-			ParashaEnums.Triennial.List
-			.Where(w => w.Date == ParashaEnums.Constants.GetNextShabbatDate())
-			.SingleOrDefault();
+		Triennial? _reading = Triennial.List.Where(w => w.Value == id).SingleOrDefault();
 
 		if (_reading is null)
 		{
-			Logger!.LogWarning("{CalledBy}; _reading is null", calledBy);
-			Toast!.ShowWarning($"Current reading is not found; called by: {calledBy}");
-
-			//ToDo: maybe I should set it to a default e.g. Gen 1:1
+			Logger!.LogWarning("{id}; _reading is null", id);
+			Toast!.ShowWarning($"Current reading is not found; id: {id}");
 			return null;
 		}
 		else
@@ -100,19 +110,23 @@ else
 		}
 	}
 
-	private ParashaEnums.Permutation GetCurrentPermutation()
+	private Permutation GetCurrentPermutation()
 	{
 		int _permutation = CascadingAppState!.AppState!.ParashaState!.Get();
 		//Logger!.LogInformation("{Method}, _permutation: {_permutation}", nameof(GetCurrentPermutation), _permutation);
-		return (ParashaEnums.Permutation)_permutation;
+		return (Permutation)_permutation;
 	}
 
-
-	private async Task ReturnedPermutation(ParashaEnums.Permutation permutation)
+	private async Task ReturnedPermutation(Permutation permutation)
 	{
 		CurrentPermutations = permutation;
 		//Logger!.LogInformation("{Method} CurrentPermutations: {CurrentPermutations}", nameof(ReturnedPermutation), CurrentPermutations);
 		await CascadingAppState!.AppState!.ParashaState!.Update(CurrentPermutations);
 	}
 
+	private void ReturnedTriennial(Triennial triennial)
+	{
+		CurrentReading = triennial;
+		if (CurrentReading is not null) { PageTitleDetail = CurrentReading.TorahAbrv; }
+	}
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/Buttons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/Buttons.razor
@@ -1,0 +1,76 @@
+﻿@using MyHebrewBible.Client.Features.Parasha.Enums
+@using MyHebrewBible.Client.Enums
+
+@inject NavigationManager NavigationManager
+
+<nav class="navbar navbar-expand bg-primary-subtle fixed-top">
+
+	<div class="collapse navbar-collapse justify-content-start">
+		<div class="ps-1">
+			<MyHebrewBible.Client.Layout.HomeButton />
+		</div>
+	</div>
+
+	@if (CurrentReading is null)
+	{
+		<text><span class="text-center fw-bold fst-italic">CurrentReading is null</span></text>
+	}
+	else
+	{
+		<div class="collapse navbar-collapse justify-content-center">
+			@if (CurrentReading.HasPrevious)
+			{
+				<div class="pe-2">
+					<PreviousOrNextButton PrevNextVM="CurrentReading.PreviousVM"
+																OnTriennialSelected="ReturnedPrevNextVM" />
+				</div>
+			}
+			else
+			{
+				<div class="pe-2">
+					<OnEdgeButton />
+				</div>
+			}
+
+			<div class="px-1">
+				<h4 class=""><i class="@Nav.Parasha.Icon"></i>&nbsp;@Nav.Parasha.Title</h4>
+			</div>
+
+			@if (CurrentReading.HasNext)
+			{
+				<div class="ps-2">
+					<PreviousOrNextButton PrevNextVM="CurrentReading.NextVM"
+																OnTriennialSelected="ReturnedPrevNextVM" />
+				</div>
+			}
+			else
+			{
+				<div class="ps-2">
+					<OnEdgeButton />
+				</div>
+			}
+
+
+		</div>
+	}
+	<div class="collapse navbar-collapse justify-content-end">
+		<div class="pe-1">
+			<NavToParashaListButton />
+		</div>
+		<div class="pe-1">
+			<PageInstructions />
+		</div>
+	</div>
+
+</nav>
+
+@code {
+	[Parameter, EditorRequired] public Triennial? CurrentReading { get; set; }
+	[Parameter, EditorRequired] public EventCallback<Triennial> OnTriennialSelected { get; set; }
+
+	private void ReturnedPrevNextVM(PrevNextVM prevNextVM)
+	{
+		NavigationManager!.NavigateTo(prevNextVM.Url);
+		OnTriennialSelected.InvokeAsync(prevNextVM.Triennial);
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/NavToParashaListButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/NavToParashaListButton.razor
@@ -1,0 +1,10 @@
+﻿@using MyHebrewBible.Client.Enums
+
+<a class="btn btn-primary" title="@Nav.ParashaList.Title" href="@Nav.ParashaList.Index">
+	<i class="@Nav.ParashaList.Icon"></i>
+</a>
+
+
+@code {
+
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/OnEdgeButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/OnEdgeButton.razor
@@ -1,0 +1,3 @@
+﻿<button class="btn btn-light btn-md disabled">
+	<span class="text-black-50"><i class="fas fa-ban"></i></span>
+</button>

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/PageInstructions.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/PageInstructions.razor
@@ -1,0 +1,20 @@
+﻿
+<LearnMoreModalTemplate Icon="fas fa-info" IconColor="btn-primary">
+	<ChildHeaderContent>
+		<h4 class="modal-title">Drill down to see the Hebrew❗</h4>
+	</ChildHeaderContent>
+	<ChildBodyContent>
+		<p class="mt-3"><b>1<sup>st</sup></b> Click the verse number e.g. <sup class="btn btn-outline-primary py-0 px-1"><b>1</b></sup>.</p>
+		<p class="ms-3 mt-1">
+			This will highlight selected verse and breaking it down into word segments.
+			<br /> e.g. <span class="bg-info-subtle me-2 text-decoration-underline">In the beginning</span> <span class="bg-info-subtle text-decoration-underline me-2">God</span> <span class="bg-info-subtle me-2">...</span>
+		</p>
+		<p class="mt-4"><b>2<sup>nd</sup></b> Click one of the word segment to see the Hebrew word.</p>
+		<p class="ms-3 mt-1">This will show the Hebrew word(s) that correspond to the chosen word segment.</p>
+	</ChildBodyContent>
+</LearnMoreModalTemplate>
+
+@code {
+
+}
+

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/PrevNextVM.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/PrevNextVM.cs
@@ -1,0 +1,5 @@
+﻿using MyHebrewBible.Client.Features.Parasha.Enums;
+
+namespace MyHebrewBible.Client.Features.Parasha.Toolbar;
+
+public record PrevNextVM(Triennial Triennial, string Url, string Icon);

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/PreviousOrNextButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Toolbar/PreviousOrNextButton.razor
@@ -1,0 +1,23 @@
+﻿@using MyHebrewBible.Client.Enums
+@using MyHebrewBible.Client.Components.BibleLookup.Toolbar.PrevNext
+@using MyHebrewBible.Client.Features.Parasha.Enums
+
+<button type="button" class="btn btn-outline-primary" title="@Title"
+				@onclick="ButtonClick">
+	<i class="@Icon"></i>
+</button>
+
+@code {
+	[Parameter, EditorRequired] public PrevNextVM? PrevNextVM { get; set; }
+	[Parameter, EditorRequired] public EventCallback<PrevNextVM> OnTriennialSelected { get; set; }
+
+	private string Icon => PrevNextVM!.Icon;
+	private string Title => PrevNextVM!.Triennial.TorahAbrv;
+
+	private void ButtonClick()
+	{
+		OnTriennialSelected.InvokeAsync(PrevNextVM);
+	}
+
+}
+

--- a/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/FilterPills.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/FilterPills.razor
@@ -1,5 +1,5 @@
 ﻿
-<div class="d-flex justify-content-start mt-2">
+<div class="d-flex justify-content-start mt-5">
 	@* nav-pills nav-tabs *@
 	<ul class="nav nav-tabs">	@* justify-content-center *@
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Index.razor
@@ -1,9 +1,13 @@
 ﻿@page "/ParashaList"
 
 @using MyHebrewBible.Client.Enums
+@using MyHebrewBible.Client.Features.ParashaList.Toolbar
 
+<PageTitle>@Nav.ParashaList.Title</PageTitle> 
 
-<PageHeader PageEnum="@MyHebrewBible.Client.Enums.Nav.ParashaList" BorderCSS="" />
+<Buttons />
+<br />
+<br />
 
 <FilterPills CurrentFilter="@CurrentFilter"
              OnFilterSelected="@ReturnedFilter" />

--- a/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Table.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Table.razor
@@ -1,6 +1,7 @@
 ﻿@using MyHebrewBible.Client.Enums
 @using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
 
+@inject NavigationManager NavigationManager
 
 <div class="pb-n1  mb-3 border-bottom border-info"></div>
 
@@ -39,7 +40,13 @@
 			}
 
 			<tr>
-				<td>@item.TriNum</td>
+				<td>
+					<button type="button" class="btn btn-sm btn-outline-primary" title="@item.TriNum"
+									@onclick="@(e => ButtonClick(item.Url))">
+						 <i class="fas fa-arrow-down"></i>
+						@*  "						*@
+					</button>
+				</td>
 
 				@if (MediaQuery != MediaQuery.XsOrSm)
 				{
@@ -96,5 +103,10 @@
 		//CurrentFilter = TorahBookFilter;
 		//CurrentFilter = TorahBookFilter.Genesis;
 		Colspan = (MediaQuery != MediaQuery.XsOrSm) ? "8" : "6";
+	}
+
+	private void ButtonClick(string url)
+	{
+		NavigationManager!.NavigateTo(url);
 	}
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Toolbar/Buttons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Toolbar/Buttons.razor
@@ -1,0 +1,31 @@
+﻿@using MyHebrewBible.Client.Enums
+@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
+
+
+<nav class="navbar navbar-expand bg-primary-subtle fixed-top">
+
+	<div class="collapse navbar-collapse justify-content-start">
+
+		<div class="ps-1">
+			<MyHebrewBible.Client.Layout.HomeButton />
+		</div>
+	</div>
+
+	<div class="collapse navbar-collapse justify-content-center">
+		<div class="px-1">
+			<h4 class=""><i class="@Nav.ParashaList.Icon"></i>&nbsp;@Nav.ParashaList.Title</h4>
+		</div>
+	</div>
+
+	<div class="collapse navbar-collapse justify-content-end">
+		<div class="pe-1">
+			<NavBackToParashaButton ReturnUrl="@ReturnUrl" />
+		</div>
+
+	</div>
+
+</nav>
+
+@code {
+	private string? ReturnUrl => ParashaEnums.Constants.GetUrl();
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Toolbar/NavBackToParashaButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/ParashaList/Toolbar/NavBackToParashaButton.razor
@@ -1,0 +1,19 @@
+﻿@using MyHebrewBible.Client.Enums
+@using ParashaEnums = MyHebrewBible.Client.Features.Parasha.Enums
+
+@inject NavigationManager NavigationManager
+
+<button @onclick="ButtonClicked" class="btn btn-primary" title="@Nav.Parasha.Title"
+				href="@Nav.Parasha.Index">
+	<i class="@Nav.Parasha.Icon"></i>
+</button>
+
+@code {
+	
+	[Parameter, EditorRequired] public string? ReturnUrl { get; set; }
+
+	private void ButtonClicked() 
+	{
+		NavigationManager!.NavigateTo(ReturnUrl!);
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Index.razor
@@ -63,7 +63,7 @@
 			Header header = state!.GetHeader();
 			CurrentHeader = new BookAndChapter(BibleBook.FromValue(_state.BibleBookId), _state.Chapter);
 			*/
-			DetailRecord bcv = CascadingAppState!.AppState!.VerseListState2!.GetBCV();
+			DetailRecord bcv = CascadingAppState!.AppState!.VerseListState!.GetBCV();
 			BookAndChapter bookAndChapter = new BookAndChapter(GlobalEnums.BibleBook.FromValue(bcv.BibleBookId), bcv.Chapter);
 			CurrentVM = new BookChapterVerse(bookAndChapter, bcv.BegVerse);
 			//PageTitle = GlobalEnums.BibleBookFormat.BCV(CurrentVM); 
@@ -80,7 +80,7 @@
 	{
 		CurrentVM = vm!;
 		//state!.UpdateHeader(new VerseListState(CurrentBookAndChapter.BibleBook!.Value, CurrentBookAndChapter.Chapter));
-		await CascadingAppState!.AppState!.VerseListState2!.UpdateBCV(new DetailRecord(vm.BookAndChapter.BibleBook, vm.BookAndChapter.Chapter, vm.Verse, vm.Verse, "Just Got Updated"));
+		await CascadingAppState!.AppState!.VerseListState!.UpdateBCV(new DetailRecord(vm.BookAndChapter.BibleBook, vm.BookAndChapter.Chapter, vm.Verse, vm.Verse, "Just Got Updated"));
 	}
 
 }

--- a/MyHebrewBible/MyHebrewBible.Client/State/AppState.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/State/AppState.cs
@@ -6,7 +6,7 @@ public class AppState
 {
 	public BookChapterState? BookChapterState { get; }
 	public ParashaState? ParashaState { get; }
-	public VerseList.VerseListState2? VerseListState2 { get; }
+	public VerseList.VerseListState? VerseListState { get; }
 
 	#region Constructor and DI
 	private readonly ILogger? Logger;
@@ -18,7 +18,7 @@ public class AppState
 		this.localStorage = localStorage;
 		BookChapterState = new BookChapterState(localStorage, logger);
 		ParashaState = new ParashaState(localStorage, logger);
-		VerseListState2 = new VerseList.VerseListState2(localStorage, logger);
+		VerseListState = new VerseList.VerseListState(localStorage, logger);
 		//Logger!.LogInformation("ctor of {Project}!{Class}", nameof(MyHebrewBible.Client), nameof(AppState));
 	}
 	#endregion
@@ -34,7 +34,7 @@ public class AppState
 			{
 				await BookChapterState!.Initialize();
 				await ParashaState!.Initialize();
-				await VerseListState2!.Initialize();
+				await VerseListState!.Initialize();
 				//Logger!.LogWarning("{Method} ParashaState.Get: {ParashaState}"
 				//	, nameof(Initialize), ParashaState.Get());
 				_isInitialized = true;

--- a/MyHebrewBible/MyHebrewBible.Client/State/VerseList/VerseListState.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/State/VerseList/VerseListState.cs
@@ -3,18 +3,18 @@ using MyHebrewBible.Client.Enums;
 
 namespace MyHebrewBible.Client.State.VerseList;
 
-public class VerseListState2
+public class VerseListState
 {
 	//private readonly ILocalStorageService? localStorage;
 	#region Constructor and DI
 	private readonly ILogger Logger;
 	private readonly ILocalStorageService? localStorage;
 
-	public VerseListState2(ILocalStorageService localStorage, ILogger<AppState> logger)
+	public VerseListState(ILocalStorageService localStorage, ILogger<AppState> logger)
 	{
 		this.localStorage = localStorage;
 		Logger = logger;
-		//Logger!.LogInformation("{Class}!{MethodEvent}", nameof(VerseListState2), "CTOR");
+		//Logger!.LogInformation("{Class}!{MethodEvent}", nameof(VerseListState), "CTOR");
 	}
 	#endregion
 

--- a/MyHebrewBible/MyHebrewBible/Database/Queries/Parasha.sql
+++ b/MyHebrewBible/MyHebrewBible/Database/Queries/Parasha.sql
@@ -1,0 +1,1 @@
+﻿SELECT Id, Torah, ParashaName, NameUrl FROM Parasha


### PR DESCRIPTION
# Commit | branch: 037-Parasha-route-parms-prev-next

# Components

## PageHeader
removed logic specific to Parasha[List]

# Features 

## BookChapter
### `Index.razor`, made the PageTitle update caused by Prev/Next events

## Home
`FancyFatNavButton.razor`
-  Added special Navigation logic to Parasha (like how it is for BookChapter)


## Parasha

#### Parasha `Index` code behind

![Parasha-Index](https://github.com/user-attachments/assets/d7208ce4-9bdc-4c29-9b6f-b70b50929bec)


#### `Buttons` and `PreviousOrNextButton` code behind

![Buttons-and-PreviousOrNextButton](https://github.com/user-attachments/assets/b0b80bce-42c4-4735-ab6b-18ae17ad4c97)


### Enums
#### Constants.cs
- Added method `PrevNextUrl(Triennial triennial)` that 
- Added method ` GetUrl()`
#### `Triennial<SmartEnum>`
added these properties
- `HasPrevious` and `HasNext`
- `PrevNextVM? PreviousVM` and `PrevNextVM? PreviousVM`
- `Url`

### Toolbar, added...
- Buttons
- NavToParashaListButton
- OnEdgeButton
- PageInstructions
- PreviousOrNextButton
- PrevNextVM

The interesting part of `Buttons.razor` is that's it's a wrapper around `PreviousOrNextButton.razor` (and other components).

- `Index.razor` is the parent
- `Buttons.razor` is child 
- `PreviousOrNextButton.razor` is the grandchild 

All of this is under the Vertical slice of **Features/Parasha** 📁


## ParashaList

#### Screen Shot

![ParashaList](https://github.com/user-attachments/assets/d22e8d5d-2c2a-439b-a941-3ea59ce580e1)


- these changes embrace the use of `NavigationManager` when going to ParashaList

### Buttons
- Added new toolbar for `ParashaList.razor`
- Added Navigation buttons to  `Table.razor`


