### PR TITLE
Ported Standalone Aleph Tav's from my old MHB Core RP project

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Enums/Nav.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/Nav.cs
@@ -212,7 +212,8 @@ public abstract class Nav : SmartEnum<Nav>
 	private sealed class AlephTavsSE : Nav
 	{
 		public AlephTavsSE() : base($"{nameof(Id.AlephTavs)}", Id.AlephTavs) { }
-		public override string Index => "/AlephTavs";
+		//public override string Index => "/AlephTavs";
+		public override string Index => "/alephTavlist";
 		public override string Title => "Aleph Tavs";
 		public override string Icon => "fa-letter-aleph-tav";
 		public override int Sort => Id.AlephTavs;
@@ -220,7 +221,17 @@ public abstract class Nav : SmartEnum<Nav>
 		public override string HomeFloatRightHebrew => "אֵת";
 		public override PageListType PageListType => PageListType.SitemapPage | PageListType.Layout;
 		public override bool IsPartOfList(PageListType pageListType) => (PageListType & pageListType) == pageListType;
-		public override bool Disabled => true;
+		public override bool Disabled => false;
+
+		/*
+			public const string PageIndexFromRoot = "/AlephTav/Index";
+			public const string PageIntroductionFromRoot = "/AlephTav/Introduction";
+			public const string PageIndex = "./Index";
+			public const string PageSummaryAndAnomalies = "./SummaryAndAnomalies";
+			public const string PageDetails = "./Details";
+			
+		 */
+
 	}
 
 	private sealed class BibleListSE : Nav

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/AlephTavScripture.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/AlephTavScripture.cs
@@ -1,0 +1,19 @@
+﻿//using System.ComponentModel.DataAnnotations;
+
+namespace MyHebrewBible.Client.Features.AlephTav;
+
+public class AlephTavScripture
+{
+	public int ID { get; set; }
+	public string? BCV { get; set; }
+	public byte BookID { get; set; }
+	public byte Chapter { get; set; }
+	public byte Verse { get; set; }
+	public string? VerseOffset { get; set; }
+	public string? KJV { get; set; }
+	public string? Hebrew2 { get; set; }
+	public string? Interlinear { get; set; }
+	public string? InterlinearKjv { get; set; }
+	//[MaxLength(500)]
+	public string? CommentsMD { get; set; }
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/AlephTavSummary.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/AlephTavSummary.cs
@@ -1,0 +1,74 @@
+﻿namespace MyHebrewBible.Client.Features.AlephTav;
+
+public class AlephTavSummary
+{
+	public int Id { get; set; }
+	public string? Abrv { get; set; }
+	public int RowCntVerses { get; set; }
+	public int RowCntAlephTavs { get; set; }
+	public int BookGroupId { get; set; }
+	public string? BookGroupDescription { get; set; }
+}
+
+public class AlephTavSummaryFactory
+{
+
+	public static IQueryable<AlephTavSummary> GetAlephTavSummaryBooks()
+	{
+		return new List<AlephTavSummary>
+			{
+new AlephTavSummary {Id = 1, Abrv = "Gen", RowCntVerses = 44, RowCntAlephTavs = 47, BookGroupId = 1, BookGroupDescription = "Torah"},
+new AlephTavSummary {Id = 2, Abrv = "Exo", RowCntVerses = 61, RowCntAlephTavs = 63, BookGroupId = 1, BookGroupDescription = "Torah"},
+new AlephTavSummary {Id = 3, Abrv = "Lev", RowCntVerses = 30, RowCntAlephTavs = 31, BookGroupId = 1, BookGroupDescription = "Torah"},
+new AlephTavSummary {Id = 4, Abrv = "Num", RowCntVerses = 42, RowCntAlephTavs = 43, BookGroupId = 1, BookGroupDescription = "Torah"},
+new AlephTavSummary {Id = 5, Abrv = "Deu", RowCntVerses = 38, RowCntAlephTavs = 39, BookGroupId = 1, BookGroupDescription = "Torah"},
+new AlephTavSummary {Id = 6, Abrv = "Jos", RowCntVerses = 21, RowCntAlephTavs = 21, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 7, Abrv = "Jdg", RowCntVerses = 19, RowCntAlephTavs = 20, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 8, Abrv = "Rut", RowCntVerses = 7, RowCntAlephTavs = 9, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 9, Abrv = "1Sa", RowCntVerses = 39, RowCntAlephTavs = 41, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 10, Abrv = "2Sa", RowCntVerses = 29, RowCntAlephTavs = 30, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 11, Abrv = "1Ki", RowCntVerses = 35, RowCntAlephTavs = 37, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 12, Abrv = "2Ki", RowCntVerses = 30, RowCntAlephTavs = 30, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 13, Abrv = "1Ch", RowCntVerses = 12, RowCntAlephTavs = 12, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 14, Abrv = "2Ch", RowCntVerses = 24, RowCntAlephTavs = 24, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 16, Abrv = "Neh", RowCntVerses = 7, RowCntAlephTavs = 7, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 17, Abrv = "Est", RowCntVerses = 13, RowCntAlephTavs = 13, BookGroupId = 2, BookGroupDescription = "History"},
+new AlephTavSummary {Id = 18, Abrv = "Job", RowCntVerses = 2, RowCntAlephTavs = 2, BookGroupId = 3, BookGroupDescription = "Poetry (Wisdom)"},
+new AlephTavSummary {Id = 19, Abrv = "Psa", RowCntVerses = 6, RowCntAlephTavs = 6, BookGroupId = 3, BookGroupDescription = "Poetry (Wisdom)"},
+new AlephTavSummary {Id = 20, Abrv = "Pro", RowCntVerses = 2, RowCntAlephTavs = 2, BookGroupId = 3, BookGroupDescription = "Poetry (Wisdom)"},
+new AlephTavSummary {Id = 21, Abrv = "Ecc", RowCntVerses = 4, RowCntAlephTavs = 4, BookGroupId = 3, BookGroupDescription = "Poetry (Wisdom)"},
+new AlephTavSummary {Id = 22, Abrv = "Son", RowCntVerses = 5, RowCntAlephTavs = 5, BookGroupId = 3, BookGroupDescription = "Poetry (Wisdom)"},
+new AlephTavSummary {Id = 23, Abrv = "Isa", RowCntVerses = 22, RowCntAlephTavs = 22, BookGroupId = 4, BookGroupDescription = "Major Prophets"},
+new AlephTavSummary {Id = 24, Abrv = "Jer", RowCntVerses = 58, RowCntAlephTavs = 62, BookGroupId = 4, BookGroupDescription = "Major Prophets"},
+new AlephTavSummary {Id = 25, Abrv = "Lam", RowCntVerses = 1, RowCntAlephTavs = 1, BookGroupId = 4, BookGroupDescription = "Major Prophets"},
+new AlephTavSummary {Id = 26, Abrv = "Eze", RowCntVerses = 39, RowCntAlephTavs = 41, BookGroupId = 4, BookGroupDescription = "Major Prophets"},
+new AlephTavSummary {Id = 27, Abrv = "Dan", RowCntVerses = 6, RowCntAlephTavs = 6, BookGroupId = 4, BookGroupDescription = "Major Prophets"},
+new AlephTavSummary {Id = 30, Abrv = "Amo", RowCntVerses = 3, RowCntAlephTavs = 3, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+new AlephTavSummary {Id = 31, Abrv = "Oba", RowCntVerses = 2, RowCntAlephTavs = 2, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+new AlephTavSummary {Id = 33, Abrv = "Mic", RowCntVerses = 2, RowCntAlephTavs = 2, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+new AlephTavSummary {Id = 36, Abrv = "Zep", RowCntVerses = 2, RowCntAlephTavs = 2, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+new AlephTavSummary {Id = 37, Abrv = "Hag", RowCntVerses = 1, RowCntAlephTavs = 1, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+new AlephTavSummary {Id = 38, Abrv = "Zec", RowCntVerses = 3, RowCntAlephTavs = 3, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+new AlephTavSummary {Id = 39, Abrv = "Mal", RowCntVerses = 3, RowCntAlephTavs = 3, BookGroupId = 5, BookGroupDescription = "Minor Prophets"},
+		}.AsQueryable();
+	}
+	/*
+
+SELECT CodeGen FROM vwAlephTavSummaryCodeGen ORDER BY Id
+
+SELECT 
+'new AlephTavSummary {' +
+'Id = ' + CAST(ID AS varchar(4)) + 
+', Abrv = "' + Abrv  + 
+'", RowCntVerses = ' + CAST(RowCntVerses AS varchar(4)) + 
+', RowCntAlephTavs = ' + CAST(RowCntAlephTavs AS varchar(4)) + 
+', BookGroupId = ' + CAST(BookGroupId AS varchar(4)) + 
+', BookGroupDescription = "' + BookGroup + '"},'  
+AS CodeGen
+, Id
+FROM AlephTavSummary
+
+	*/
+
+}
+

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Constants.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Constants.cs
@@ -1,0 +1,23 @@
+﻿namespace MyHebrewBible.Client.Features.AlephTav;
+
+public class Constants { }
+
+public static class PartialViews
+{
+	public const string WordsMinimal = "_WordsMinimal";
+	public const string AlephTavPopover = "_AlephTavPopover";
+	public const string Details = "_Details";
+}
+
+public static class VDD // Constants for ViewDataDictionary
+{
+	public const string ScriptureID = "ScriptureId";
+	public const string IsXs = "IsXs";
+}
+
+//	Hack, see Task 75:
+public static class UrlAction
+{
+	public const string Controller = "AlephTav";
+	public const string Index = "Index";
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Details.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Details.razor
@@ -1,0 +1,91 @@
+﻿<h3>Details</h3>
+
+
+<h3 class="text-center">
+	<b>@VM.AlephTavScripture.BCV</b> <em>@VM.AlephTavScripture.VerseOffset</em>
+
+@* 	<a asp-page="@Anchors.AlephTav.PageDetails ./Details " asp-route-id="@VM.AlephTavScripture.ID"
+		 title="@VM.AlephTavScripture.ID">
+		<span class="text-muted"><sup><small><i class="fa fa-location-arrow" aria-hidden="true">&nbsp;</i></small></sup></span>
+	</a>
+ *@
+</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<h4><span class="label label-info">KJV</span></h4>
+		<p>
+			@((MarkupString)VM.AlephTavScripture.KJV!)
+		</p>
+
+		<h4><span class="label label-info">Interlinear KJV</span></h4>
+		<p>
+			<span class="hebrew">
+				@((MarkupString)VM.AlephTavScripture.InterlinearKjv!)
+			</span>
+		</p>
+
+		<h4><span class="label label-info">Interlinear</span></h4>
+		<p class="hebrew medium">
+			@((MarkupString)VM.AlephTavScripture.Interlinear!)
+		</p>
+
+		<h4><span class="label label-info">Hebrew2</span></h4>
+		<p class="hebrew medium">
+			@((MarkupString)VM.AlephTavScripture.Hebrew2!)
+		</p>
+
+		@if (!String.IsNullOrEmpty(VM.AlephTavScripture.CommentsMD))
+		{
+			<h3><span class="text-info">Comments</span><br /></h3>
+			<p>
+				@((MarkupString)VM.AlephTavScripture.CommentsMD!)
+			</p>
+		}
+
+	</div>
+
+	<div class="col-md-6">
+		@* 		
+		<div class="visible-xs">
+		@await Html.PartialAsync(PartialViews.WordsMinimal, Model.Words, new ViewDataDictionary(this.ViewData) { { VDD.ScriptureID, Model.AlephTavScripture.ID }, { VDD.IsXs, true } })
+		</div>
+		<div class="hidden-xs">
+			@await Html.PartialAsync(PartialViews.WordsMinimal,
+			Model.Words, new ViewDataDictionary(this.ViewData) { { VDD.ScriptureID, Model.AlephTavScripture.ID }, { VDD.IsXs, false } })
+		</div> 
+		*@
+
+	</div>
+
+</div>
+
+@code {
+	public DetailsVM VM { get; set; }
+
+	protected override void OnInitialized()
+	{
+		VM = new DetailsVM
+			{
+				AlephTavSummaryBooks = AlephTavSummaryFactory.GetAlephTavSummaryBooks()
+			};
+
+		//VM.AlephTavScripture = await db.ScriptureByIdAsync(id);
+		//VM.Words = await db.WordsByScriptureIdAsync(id);
+	}
+
+
+
+	//@await Html.PartialAsync(PartialViews.AlephTavPopover, Model.VM.AlephTavSummaryBooks)
+
+		/*
+	*
+	private readonly IAlephTavRepository db;
+
+	AlephTavSummaryBooks = AlephTavSummaryFactory.GetAlephTavSummaryBooks()
+
+				VM.AlephTavScripture = await db.ScriptureByIdAsync(id);
+			log.LogInformation($"ScriptureByIdAsync");
+			VM.Words = await db.WordsByScriptureIdAsync(id);
+	*/
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/DetailsVM.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/DetailsVM.cs
@@ -1,0 +1,8 @@
+﻿namespace MyHebrewBible.Client.Features.AlephTav;
+
+public class DetailsVM
+{
+	public AlephTavScripture AlephTavScripture { get; set; }
+	public List<WordHtmlMinimal> Words { get; set; }
+	public IEnumerable<AlephTavSummary> AlephTavSummaryBooks { get; set; }
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Enums/Filter.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Enums/Filter.cs
@@ -1,0 +1,57 @@
+﻿namespace MyHebrewBible.Client.Features.AlephTav.Enums;
+
+using Ardalis.SmartEnum;
+
+public abstract class Filter : SmartEnum<Filter>
+{
+
+	#region Id's
+	private static class Id
+	{
+		// Class ArticleList
+		//internal const int All = 0;
+		internal const int Summary = 1;       
+		internal const int All613 = 2;    
+	}
+	#endregion
+
+	#region  Declared Public Instances
+	//public static readonly Filter All = new AllSE();
+	public static readonly Filter Summary = new SummarySE();
+	public static readonly Filter All613 = new All613SE();
+	#endregion
+
+	private Filter(string name, int value) : base(name, value)  // Constructor
+	{
+	}
+
+	#region Extra Fields
+	public abstract string Title { get; }
+	//public abstract string Where { get; }
+	#endregion
+
+	#region Private Instantiation
+
+	//private sealed class AllSE : Filter
+	//{
+	//	public AllSE() : base($"{nameof(Id.All)}", Id.All) { }
+	//	public override string Title => "All";
+	//	public override string Where => ""; 
+	//}
+
+	private sealed class SummarySE : Filter
+	{
+		public SummarySE() : base($"{nameof(Id.Summary)}", Id.Summary) { }
+		public override string Title => "Summary";
+		//public override string Where => " WHERE zzz ";
+	}
+
+	private sealed class All613SE : Filter
+	{
+		public All613SE() : base($"{nameof(Id.All613)}", Id.All613) { }
+		public override string Title => "See all 634";
+		//public override string Where => " WHERE zzz ";
+	}
+
+	#endregion
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Filter.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Filter.razor
@@ -1,0 +1,36 @@
+﻿@*  *@
+<div class="d-flex justify-content-end">
+	@foreach (var item in Enums.Filter.List.OrderBy(o => o.Value))
+	{
+		<div class="pe-1">
+			<button @onclick="@(() => OnClick(item))" title="Filter by @item.Title"
+							class="btn btn-outline-primary btn-sm  @ActiveFilter(item)">
+				@item.Title
+			</button>
+		</div>
+	}
+</div>
+
+@* 	
+	<div class="row mt-3">
+	<div class="col-12">
+</div>
+</div> 
+*@
+
+
+@code {
+	[Parameter, EditorRequired] public Enums.Filter? CurrentFilter { get; set; }
+	[Parameter, EditorRequired] public EventCallback<Enums.Filter> OnFilterSelected { get; set; }
+
+	private async Task OnClick(Enums.Filter filter)
+	{
+		await OnFilterSelected.InvokeAsync(filter);
+	}
+
+	public string ActiveFilter(Enums.Filter filter)
+	{
+		if (filter == CurrentFilter) { return "active"; }
+		else { return ""; }
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Index.razor
@@ -1,11 +1,55 @@
-﻿@page "/AlephTavs"
+﻿@page "/alephtavlist/{BookId:int}"
+
+@using MyHebrewBible.Client.Enums
 
 <PageHeader PageEnum="@MyHebrewBible.Client.Enums.Nav.AlephTavs" />
 
-<p class="text-danger">NOT DONE YET!</p>
+<Table _bibleBook="CurrentBibleBook" />
+
+<Filter CurrentFilter="CurrentFilter"
+				OnFilterSelected="@ReturnedFilter" />
+
+<div class="@GlobalEnums.MediaQuery.Xs.DivClass">
+	<Introduction IsXs=true />
+</div>
+
+<div class="@GlobalEnums.MediaQuery.SmOrMdOrLgOrXl.DivClass">
+	<Introduction IsXs=false />
+</div>
+
+<PageSummaryAndAnomalies />
+
+<SummaryTable />
 
 @code {
+	protected Enums.Filter CurrentFilter { get; set; } = Enums.Filter.Summary;
+
+	[Parameter, EditorRequired] public int BookId { get; set; }
+
+	protected override void OnInitialized()
+	{
+		//Logger!.LogInformation("{Method}, Route: {BookId}/{Chapter}", nameof(OnInitialized), BookId, Chapter);
+		CurrentBibleBook = GetBookViaRoutes(BookId);
+	}
+
+		private BibleBook GetBookViaRoutes(int bookId)
+	{
+		BibleBook bibleBook = BibleBook.FromValue(bookId); ;
+		//bibleBook = new BibleBook(BibleBook.FromValue(bookId));
+		//PageTitle = GlobalEnums.BibleBookFormat.BC(bc);
+		return bibleBook;
+	}
+	public BibleBook? CurrentBibleBook { get; set; }
+
+	private async Task ReturnedFilter(Enums.Filter filter)
+	{
+		await Task.Delay(5);
+		CurrentFilter = filter;
+		//await OnArticleIdSelected.InvokeAsync(0);
+		//await PopulateCollection(filter);
+	}
+
 	// protected override void OnInitialized()
 	// {
-	// }
+		// }
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Introduction.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Introduction.razor
@@ -1,0 +1,126 @@
+﻿
+<h2><span class="text-danger">את</span> Standalone Aleph Tav</h2>
+<p>
+	This page is a short introduction into the Standalone Aleph Tav.
+	There are 612 verses (by my count) that have one of these special type of Aleph Tav's in them.
+	One of the features of <b>My Hebrew Bible</b> is that they have been highligted in red <span class="text-danger">את</span>.
+</p>
+
+@* 
+	<a asp-page="@Anchors.AlephTav.PageIndex" class="btn btn-lg btn-success">   
+		PageIndex = "./Index";
+		See all 634
+		<span class="fa fa-arrow-circle-right "></span>
+		
+	<a asp-page="@Anchors.AlephTav.PageSummaryAndAnomalies" class="btn btn-lg btn-success"> 
+		PageSummaryAndAnomalies = "./SummaryAndAnomalies";
+		Summary
+		<span class="fa fa-arrow-circle-right "></span>
+		
+*@
+
+<h4>Why a Standalone Aleph Tav List?</h4>
+<p>
+	In the Hebrew language it is called a <a href="https://en.wikipedia.org/wiki/Modern_Hebrew_grammar#Direct_objects" target="_blank">direct object</a>,
+	but I believe it <b>points</b> to the Messiah.
+</p>
+
+<p>Here is the first occurrence.  It is in the first verse of the bible</p>
+<blockquote>
+	<div class="hebrew">
+		<span class="jt-enlarged-letter">&#64305</span>&#1456&#1512&#1461&#1488&#64298&#1460&#1497&#1514 &#64305&#1464&#1512&#1464&#1488 &#1488&#1457&#1500&#1465&#1492&#1460&#1497&#1501 <span class="at-red">&#1488&#1461&#1514</span> &#1492&#1463&#64300&#1464&#1502&#1463&#1497&#1460&#1501 &#1493&#1456&#1488&#1461&#1514 &#1492&#1464&#1488&#1464&#1512&#1462&#1509
+	</div>
+	<span class="pull-right"><small><cite>Gen 1:1 WLC</cite></small></span>
+</blockquote>
+
+<p>Here is the first verse of the book of John which I believe is alluding to Gen 1:1</p>
+<blockquote>
+	<sup>1:1</sup> In the beginning was the Word, and the Word was with God, and the Word was God.
+	<small><cite>Joh 1:1 KJV</cite></small>
+</blockquote>
+
+@if (!IsXs)
+{
+	<img src="@BlobContent.ImagesUrl("Mt_Horev_Aleph_Tav.png")" alt="Mt. Horev Aleph Tav" class="img-thumbnail" />
+}
+
+
+<blockquote>
+	<sup>1:7</sup> Behold, he cometh with clouds; and every eye shall see him, and they also which pierced him: and all kindreds of the earth shall wail because of him. Even so, Amen.
+	<sup>8</sup> <span class="text-danger">I am <del>Alpha and Omega</del> Aleph and Tav, the beginning and the ending</span>, saith the Lord, which is, and which was, and which is to come, the Almighty.
+	<small><cite>Rev 1:7-8 KJV</cite></small>
+</blockquote>
+
+<blockquote>
+	<sup>12:10</sup>
+	I will pour upon the house of David, and upon the inhabitants of Jerusalem, the spirit of grace and of supplications:
+	and they shall look upon <b>me</b> (<span class="text-danger">תא</span>)  whom they have pierced, and they shall mourn for him, as one mourneth for his only son,
+	and shall be in bitterness for him, as one that is in bitterness for his firstborn.
+	<small>Zec 12:10<cite></cite></small>
+</blockquote>
+
+<br />
+<blockquote>
+	<sup>52:10</sup> YHVH hath made bare his holy arm in the eyes of all the nations; and all the ends of the earth  (<span class="text-danger">תא</span>) shall see the salvation of our God.<br />
+	<br />
+	<div class="hebrew">
+		&#1495&#1464&#64299&#1463&#1507 &#1497&#1456&#1492&#1493&#1464&#1492 &#1488&#1462&#1514&#1470&#1494&#1456&#1512&#1465&#1493&#1506&#1463 &#1511&#1464&#1491&#1456&#64298&#1465&#1493 &#1500&#1456&#1506&#1461&#1497&#1504&#1461&#1497 &#64315&#1464&#1500&#1470&#1492&#1463&#64306&#1465&#1493&#1497&#1460&#1501 &#1493&#1456&#1512&#1464&#1488&#64309 &#64315&#1464&#1500&#1470&#1488&#1463&#1508&#1456&#1505&#1461&#1497&#1470&#1488&#1464&#1512&#1462&#1509<sup> 10</sup> <span class="at-red"> &#1488&#1461&#1514</span><sup> 11</sup> &#1497&#1456&#64298&#64309&#1506&#1463&#1514<sup> 12</sup> &#1488&#1457&#1500&#1465&#1492&#1461&#1497&#1504&#64309<sup> 13</sup>
+	</div>
+	<p class="pull-right"><small><span class="text-muted">Transliteration "...<b>aretz</b><sup> of the earth</sup> <span class="text-danger"><b>et</b></span> <b>yeshuat</b><sup> the salvation</sup> <b>eloHeinu</b><sup> of our God</sup></span> "</small></p>
+	<br />
+	<small>Isa 52:10<cite></cite></small>
+</blockquote>
+<br />
+
+<blockquote>
+	<sup>53:5</sup> But he <span class="text-muted"><i>was</i></span> wounded for our transgressions, <span class="text-muted"><i>he was</i></span> bruised for our iniquities: the chastisement of our peace <span class="text-muted"><i>was</i></span> upon him; and with his stripes we are healed.
+	<sup>6</sup> All we like sheep have gone astray; we have turned every one to his own way; and <span>יהוה</span> hath laid on <b>him</b> (<span class="text-danger">תא</span>) the iniquity of us all.
+	<small>Isa 53:5-6<cite></cite></small>
+</blockquote>
+
+@if (IsXs)
+{
+<TheRockModal />
+}
+
+
+<h5>Translation Notes</h5>
+<p>
+	<small>
+		The quotes above are from the King James bible with some changes as an attempt to point out the meaning of the <i>Aleph</i> and <i>Tav</i>.
+		The changes include of course the addition of the Hebrew letters <i>Aleph Tav</i> which are colored in red.
+		<br />
+	</small>
+</p>
+<p>
+	<small>
+		<b>Rev 1:8""</b> In Rev 1:8 the Greek transliterated word <i>Alpha</i> and <i>Omega</i> is marked up with a strike through and
+		the Hebrew equivalent transliteration of <i>Aleph</i> and <i>Tav</i> was appended next to it.
+		Both of these sets of letters <i>Alpha</i> and <i>Omega</i> for the Greek and <i>Aleph</i> and <i>Tav</i> for the Hebrew are the first and last letters for their respective languages (in English it would be like A and Z).
+		The change in the text was to emphasize the Hebrew roots of <i>Y'shua</i> (Jesus) and his disciple John the Revelator.<br />
+		The presumption made is that a Hebrew messiah speaking to a Hebrew prophet did so in the Hebrew language.
+	</small>
+</p>
+<p>
+	<small>
+		<b>About the picture:</b> The picture of the rock which is found in <i>Kadesh</i> (Num 20) or <i>Meribah-Kadesh</i> (Deu 32:51).
+		If you look closely, the letters <i>Aleph</i> and <i>Tav</i> have been embossed and are not found in the original picture.
+		Artistic license was employed to express that the rock (<i>Tsur</i>) mentioned in Deu 32 and 1Cor 10:4 had followed them in the desert.
+		And it was from this rock that the miracle of the spiritual / living water sprang forth.
+		<br />
+		The rock (<i>Tsur</i>) is also one of the names for God (<i>Elohim</i> i.e. &quot;&hellip;the Rock (<i>Tsur</i>) of his salvation (<i>yeshuato</i>)&quot; (Deu 32:15).
+	</small>
+</p>
+<p>
+	<small>
+		<b>Other Notes</b><br />
+		&bull;&nbsp; The word for <b>the LORD</b> in Isaiah 53:6 is substituted with the Hebrew word which is spelled <i>Yood Hey Vav Hey</i>.<br />
+		&bull;&nbsp; In Rev 1:8, the red letters are found in some version of the King James bible, so those colors therefore were not added.
+	</small>
+</p>
+
+
+@code {
+	//string title = "Standalone Aleph Tav";
+	[Parameter, EditorRequired] public bool IsXs { get; set; }
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/PageSummaryAndAnomalies.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/PageSummaryAndAnomalies.razor
@@ -1,0 +1,54 @@
+﻿
+<h3>@Title</h3>
+
+<p>ToDo Add Bread Crumb</p>
+
+<h2>Anomalies</h2>
+<h4>
+	<VerseParagraph VerseParagraphRange="Neh_09_06" />
+	@* <a asp-page="@Anchors.AlephTav.PageDetails" asp-route-id="@Verse.Neh_09_06_Id" title="@Verse.Neh_09_06_Title"><i class="fa fa-location-arrow" aria-hidden="true">&nbsp;</i></a> *@
+</h4>
+<p>
+	This <b>SAT</b> is unique because it is found in the <b>written</b> portion as opposed to the <b>read</b> portion.  So what do I mean by this?
+	In the Hebrew Bible called the <b>Westminster Leningrad Codex </b>(WLC)
+	<small><a href="https://en.wikipedia.org/wiki/Leningrad_Codex"><i class="fa fa-external-link" aria-hidden="true">&nbsp;</i><i class="fa fa-wikipedia-w" aria-hidden="true"></i></a></small>.
+	there are what are called the <b><i>Qere</i></b> <span class="hebrew small">קְרֵי </span><sup>(what is <b>read</b>)</sup> and <b><i>Ketiv</i></b> <span class="hebrew small">כְּתִיב </span><sup>(what is <b>written</b>)</sup>
+	<a href="https://en.wikipedia.org/wiki/Qere_and_Ketiv"><i>Qere Ketiv</i></a> <i class="fa fa-external-link">&nbsp;</i><i class="fa fa-wikipedia-w"></i>.
+	For the fifth word of Nehemiah 9:6 the <i>Ketiv</i>, the written part, it is a Standalone Aleph Tav (SAT), but the <i>Qere</i>, read part, it is an <i>Aleph Tav Hey</i>.
+	<br />
+	<img class="img-responsive" src="@BlobContent.ImagesUrl("e_sword_Neh_Chap_9_Verse_6d.png")" />
+</p>
+
+<h4>
+	<VerseParagraph VerseParagraphRange="Job_01_10" />
+	@* <a asp-page="@Anchors.AlephTav.PageDetails" asp-route-id="@Verse.Job_01_10_Id" title="@Verse.Job_01_10_Title"><i class="fa fa-location-arrow" aria-hidden="true">&nbsp;</i></a> *@
+</h4>
+<p>
+	<img class="img-responsive" src="@BlobContent.ImagesUrl("e_sword_Job_Chap_1_Verse_10.png")" />
+</p>
+
+<h4>
+	<VerseParagraph VerseParagraphRange="Psa_60_01" />
+	@* <a asp-page="@Anchors.AlephTav.PageDetails" asp-route-id="@Verse.Psa_60_01_Id" title="@Verse.Psa_60_01_Title"><i class="fa fa-location-arrow" aria-hidden="true">&nbsp;</i></a> *@
+</h4>
+<p>
+	<img class="img-responsive" src="@BlobContent.ImagesUrl("e_sword_Psa_Chap_60_Verse_1_C1068b.png")" />
+</p>
+
+
+@code {
+	int verseCnt = 0;
+	int alephTavCnt = 0;
+	string Title = "Standalone Aleph Tav List";
+
+	private VerseParagraphRange Neh_09_06 = new VerseParagraphRange(12518, 12518, "Nehemiah 9:6");
+	private VerseParagraphRange Job_01_10 = new VerseParagraphRange(12880, 12880, "Job 1:10");
+	private VerseParagraphRange Psa_60_01 = new VerseParagraphRange(14809, 14809, "Psalms 60:1");
+
+	//public IEnumerable<Bible.Domain.AlephTavSummary> AlephTavSummaryList { get; set; }
+	//AlephTavSummaryList = AlephTavSummaryFactory.GetAlephTavSummaryBooks();
+	
+
+
+	// /SummaryAndAnomalies
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/SummaryTable.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/SummaryTable.razor
@@ -1,0 +1,62 @@
+﻿<h3><span class="text-danger">את</span> Standalone Aleph Tav List</h3>
+
+<p>
+	This is a list of all the Standalone Aleph Tav's <span class="text-danger">את</span> by book.
+	<br /><br />
+	The table has two columns with a count of <i>Aleph Tav</i> occurrences for each book.
+	The first column is a count of the verses and the second column is the actual count of <i>Aleph Tav's</i>.
+	Since some verses have two <i>Aleph Tav's</i> in the same verse, that column will have a larger count.
+	The totals are listed on the bottom.
+</p>
+
+<p>
+	Below the table is a list of anomalies that I acquired when I created the list.
+</p>
+
+<div class="table-responsive">
+
+	<table class="table table-striped table-condensed">
+		<tr>
+			<th><br /><br />Book</th>
+			<th>Verses<br />with<br />Aleph Tavs</th>
+			<th>Actual<br />Aleph Tav<br />Count</th>
+		</tr>
+
+		@foreach (var item in AlephTavSummaryList!)
+		{
+			verseCnt += item.RowCntVerses;
+			alephTavCnt += item.RowCntAlephTavs;
+			<tr>
+				<td>
+					@item.Abrv @* <a asp-page="@Anchors.ParentIndex" asp-route-id="@item.Id" title="@item.Abrv">@item.Abrv</a> *@
+				</td>
+				<td>
+					@item.RowCntVerses
+				</td>
+				<td>
+					@item.RowCntAlephTavs
+				</td>
+			</tr>
+		}
+
+		<tfoot>
+			<tr>
+				<td><b>Total</b></td>
+				<td><span class="text-danger"><b>@verseCnt</b></span></td>
+				<td><span class="text-danger"><b>@alephTavCnt</b></span></td>
+			</tr>
+		</tfoot>
+	</table>
+
+</div>
+
+
+@code {
+	int verseCnt = 0;
+	int alephTavCnt = 0;
+
+	public IEnumerable<AlephTavSummary>? AlephTavSummaryList  => AlephTavSummaryFactory.GetAlephTavSummaryBooks();
+
+	//protected override void OnInitialized() 	{	}
+
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Table.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Table.razor
@@ -1,0 +1,49 @@
+﻿@using MyHebrewBible.Client.Enums
+
+@inject ApiClient Api
+
+<h3>Aleph Tav Table</h3>
+
+ @if (alephTavList == null)
+{
+	<p><em>Loading...</em></p>
+}
+else
+{
+	<table class="table">
+		<thead>
+			<tr>
+				<th>#</th>
+				<th>Detail</th>
+				<th>BCV</th>
+				<th>Hebrew</th>
+
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var item in alephTavList)
+			{
+				<tr>
+					<td><i>@item.ScriptureID</i></td>
+					<td>@item.Detail</td>
+					<td>@item.BCV</td>
+					<td class="text-end">@((MarkupString)@item.Hebrew) </td>
+					
+
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+@code {
+	[Parameter, EditorRequired] public BibleBook? _bibleBook { get; set; } 
+
+	private ICollection<AlephTavList>? alephTavList = null;
+
+	 protected override async Task OnParametersSetAsync()
+	 {
+		alephTavList = await Api.GetAlephTavByBookAsync((long)_bibleBook!.Value);
+	 }
+
+}
+

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/TheRockModal.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/TheRockModal.razor
@@ -1,0 +1,59 @@
+﻿@if (ModalIsNotShownToggle)
+{
+	<button type="button" class="btn btn-outline-primary btn-sm float-end"
+					@onclick="() => ShowModal()">
+		<i class="far fa-image fa-2x"></i> The Rock<br> at <i>Kadesh</i>
+	</button>
+
+}
+else
+{
+	<div class="@modalClass" style="display:@(modalOpen?"block":"none");">
+		<div class="modal-dialog modal-sm">
+			<div class="modal-content @modalContentColor">
+				<div class="modal-header @modalHeaderColor">
+					<p>Select Filter</p>
+					<button type="button" class="btn-close" @onclick="CloseModal"></button>
+				</div>
+
+				<div class="modal-body @modalBodyColor">
+			
+					<img src="@BlobContent.ImagesUrl("Mt_Horev_Aleph_Tav.png")" alt="Mt. Horev Aleph Tav" class="img-thumbnail" />
+
+					<blockquote>
+						<sup>10:4</sup>
+						And did all drink the same spiritual drink: for they drank of that <b>spiritual Rock</b> that followed them: and that Rock was Christ.
+						<small>1Co 10:4<cite></cite></small>
+					</blockquote>
+				</div>
+			</div>
+		</div>
+	</div>
+}
+
+@code {
+	bool ModalIsNotShownToggle = true;
+	bool modalOpen = false;
+
+	//<modal title="The Rock!" id="alephTav">
+	string modalClass = "modal";
+	//string modalSize = "modal-sm"; // : "modal-md"
+	string modalHeaderColor = "bg-warning-subtle";
+	string modalContentColor = " border-danger";
+	string modalBodyColor = "bg-warning-subtle"; 
+
+	void ShowModal()
+	{
+		modalOpen = true;
+		ModalIsNotShownToggle = false;
+		modalClass += " show";
+		StateHasChanged();
+	}
+
+	void CloseModal()
+	{
+		modalOpen = false;
+		ModalIsNotShownToggle = true;
+		modalClass = "modal";
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/WordHtmlMinimal.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/WordHtmlMinimal.cs
@@ -1,0 +1,11 @@
+﻿namespace MyHebrewBible.Client.Features.AlephTav;
+
+public class WordHtmlMinimal
+{
+	public int ScriptureID { get; set; }
+	public byte WordCount { get; set; }
+	public int? Strongs { get; set; }
+	public string? Hebrew { get; set; }
+	public string? KjvWord { get; set; }
+	public string? Transliteration { get; set; }
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Home/FancyFatNavButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Home/FancyFatNavButton.razor
@@ -50,7 +50,14 @@
 			}
 			else
 			{
-				NavigationManager!.NavigateTo(Nav.FromValue(id) + "/");
+				if (Nav.FromValue(id) == Nav.AlephTavs)
+				{
+					NavigationManager!.NavigateTo($"{Nav.FromValue(id).Index}/1");
+				}
+				else
+				{
+					NavigationManager!.NavigateTo(Nav.FromValue(id) + "/");
+				}
 			}
 		}
 

--- a/MyHebrewBible/MyHebrewBible.Client/HttpClient/ApiClient.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/HttpClient/ApiClient.cs
@@ -67,6 +67,175 @@ namespace MyHebrewBible.Client
 
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<AlephTav>> GetAlephTavAsync(long bookid, long chapter)
+        {
+            return GetAlephTavAsync(bookid, chapter, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<AlephTav>> GetAlephTavAsync(long bookid, long chapter, System.Threading.CancellationToken cancellationToken)
+        {
+            if (bookid == null)
+                throw new System.ArgumentNullException("bookid");
+
+            if (chapter == null)
+                throw new System.ArgumentNullException("chapter");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/aleptav/{bookid}/{chapter}"
+                    urlBuilder_.Append("api/aleptav/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(bookid, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append('/');
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(chapter, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<AlephTav>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<AlephTavList>> GetAlephTavByBookAsync(long bookid)
+        {
+            return GetAlephTavByBookAsync(bookid, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<AlephTavList>> GetAlephTavByBookAsync(long bookid, System.Threading.CancellationToken cancellationToken)
+        {
+            if (bookid == null)
+                throw new System.ArgumentNullException("bookid");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/aleptavlist/{bookid}"
+                    urlBuilder_.Append("api/aleptavlist/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(bookid, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<AlephTavList>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<Article> GetArticleAsync(long id)
         {
             return GetArticleAsync(id, System.Threading.CancellationToken.None);
@@ -946,6 +1115,84 @@ namespace MyHebrewBible.Client
             var result = System.Convert.ToString(value, cultureInfo);
             return result == null ? "" : result;
         }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AlephTav
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("ScriptureID")]
+        public long ScriptureID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Detail")]
+        public long Detail { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BCV")]
+        public string BCV { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BookID")]
+        public long BookID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Chapter")]
+        public long Chapter { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordCount")]
+        public long WordCount { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordEnum")]
+        public long WordEnum { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew1")]
+        public string Hebrew1 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew2")]
+        public string Hebrew2 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew3")]
+        public string Hebrew3 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew")]
+        public string Hebrew { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AlephTavList
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("ScriptureID")]
+        public long ScriptureID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Detail")]
+        public long Detail { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BCV")]
+        public string BCV { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BookID")]
+        public long BookID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Chapter")]
+        public long Chapter { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordCount")]
+        public long WordCount { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordEnum")]
+        public long WordEnum { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew1")]
+        public string Hebrew1 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew2")]
+        public string Hebrew2 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew3")]
+        public string Hebrew3 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew")]
+        public string Hebrew { get; set; }
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]

--- a/MyHebrewBible/MyHebrewBible/Database/Queries/AlephTav.sql
+++ b/MyHebrewBible/MyHebrewBible/Database/Queries/AlephTav.sql
@@ -1,0 +1,10 @@
+﻿
+SELECT at.ScriptureID, at.Detail, s.BCV, s.BookID, s.Chapter
+, wp.WordCount, wp.WordEnum, wp.Hebrew1, wp.Hebrew2, wp.Hebrew3 
+--, wp.KjvWord, wp.SegmentCount
+FROM WordPart wp
+INNER JOIN AlephTav at ON wp.ScriptureID = at.ScriptureID AND wp.WordCount = at.Word
+INNER JOIN Scripture s ON wp.ScriptureID = s.ID
+
+--SELECT ScriptureID, Detail, Word FROM AlephTav;
+--SELECT * FROM WordPart LIMIT 10

--- a/MyHebrewBible/MyHebrewBible/Database/Queries/AlephTavVerse.sql
+++ b/MyHebrewBible/MyHebrewBible/Database/Queries/AlephTavVerse.sql
@@ -1,0 +1,4 @@
+﻿SELECT ScriptureID, Verse, CommentsMD, HasTwo 
+--, BookID, BookAbrv, BookGroupID, BookGroupDescr
+FROM AlephTavVerse
+--ORDER BY ScriptureID

--- a/MyHebrewBible/MyHebrewBible/Endpoints/AlephTav.cs
+++ b/MyHebrewBible/MyHebrewBible/Endpoints/AlephTav.cs
@@ -1,0 +1,47 @@
+﻿namespace MyHebrewBible.Endpoints;
+
+public class AlephTav
+{
+	public long ScriptureID { get; set; }
+	public long Detail { get; set; }
+	public string? BCV { get; set; }
+	public long BookID { get; set; }
+	public long Chapter { get; set; }
+	public long WordCount { get; set; }
+	//public long SegmentCount { get; set; }
+	public long WordEnum { get; set; }
+	public string? Hebrew1 { get; set; }
+	public string? Hebrew2 { get; set; }
+	public string? Hebrew3 { get; set; }
+
+	public string Hebrew
+	{
+		get
+		{
+			if (WordEnum == 1) // SimpleSingle
+			{
+				return $"<span class='hebrew30'>{Hebrew1}</span>";
+			}
+			else if (WordEnum == 2) // NRL_Prefix
+			{
+				return $"<span class='hebrew30 nrl'>{Hebrew1}</span><span class='hebrew30'>{Hebrew2}</span>";
+			}
+			else if (WordEnum == 3) // NRL_Suffix
+			{
+				return $"<span class='hebrew30'>{Hebrew1}</span><span class='hebrew30 nrl'>{Hebrew2}</span>";
+			}
+			else if (WordEnum == 4) // NRL_Prefix and NRL_Suffix
+			{
+				return $"<span class='hebrew30 nrl'>{Hebrew1}</span><span class='hebrew30'>{Hebrew2}</span><span class='hebrew30 nrl'>{Hebrew3}</span>";
+			}
+			else if (WordEnum == 5) // SAT
+			{
+				return $"<span class='hebrew30 at-red'>{Hebrew1}</span>";
+			}
+			else  // SAT and Paseq
+			{
+				return $"<span class='hebrew30 at-red'>{Hebrew1}</span> <span class='last-seg-type-paseq'>׀</span>";
+			}
+		}
+	}
+}

--- a/MyHebrewBible/MyHebrewBible/Endpoints/AlephTavList.cs
+++ b/MyHebrewBible/MyHebrewBible/Endpoints/AlephTavList.cs
@@ -1,0 +1,47 @@
+﻿namespace MyHebrewBible.Endpoints;
+
+public class AlephTavList
+{
+	public long ScriptureID { get; set; }
+	public long Detail { get; set; }
+	public string? BCV { get; set; }
+	public long BookID { get; set; }
+	public long Chapter { get; set; }
+	public long WordCount { get; set; }
+	//public long SegmentCount { get; set; }
+	public long WordEnum { get; set; }
+	public string? Hebrew1 { get; set; }
+	public string? Hebrew2 { get; set; }
+	public string? Hebrew3 { get; set; }
+
+	public string Hebrew
+	{
+		get
+		{
+			if (WordEnum == 1) // SimpleSingle
+			{
+				return $"<span class='hebrew30'>{Hebrew1}</span>";
+			}
+			else if (WordEnum == 2) // NRL_Prefix
+			{
+				return $"<span class='hebrew30 nrl'>{Hebrew1}</span><span class='hebrew30'>{Hebrew2}</span>";
+			}
+			else if (WordEnum == 3) // NRL_Suffix
+			{
+				return $"<span class='hebrew30'>{Hebrew1}</span><span class='hebrew30 nrl'>{Hebrew2}</span>";
+			}
+			else if (WordEnum == 4) // NRL_Prefix and NRL_Suffix
+			{
+				return $"<span class='hebrew30 nrl'>{Hebrew1}</span><span class='hebrew30'>{Hebrew2}</span><span class='hebrew30 nrl'>{Hebrew3}</span>";
+			}
+			else if (WordEnum == 5) // SAT
+			{
+				return $"<span class='hebrew30 at-red'>{Hebrew1}</span>";
+			}
+			else  // SAT and Paseq
+			{
+				return $"<span class='hebrew30 at-red'>{Hebrew1}</span> <span class='last-seg-type-paseq'>׀</span>";
+			}
+		}
+	}
+}

--- a/MyHebrewBible/MyHebrewBible/Endpoints/GetAlephTav.cs
+++ b/MyHebrewBible/MyHebrewBible/Endpoints/GetAlephTav.cs
@@ -1,0 +1,28 @@
+﻿namespace MyHebrewBible.Endpoints;
+
+public class GetAlephTavRequest
+{
+	public long BookID { get; set; }
+	public long Chapter { get; set; }
+}
+
+public class GetAlephTav : Endpoint<GetAlephTavRequest, IEnumerable<AlephTav>>
+{
+	public override void Configure()
+	{
+		Get("/aleptav/{bookid:long}/{chapter:long}");
+		AllowAnonymous();
+	}
+
+	private readonly Repository _db;
+	public GetAlephTav(Repository repository)
+	{
+		_db = repository;
+	}
+
+	public override async Task HandleAsync(GetAlephTavRequest request, CancellationToken ct)
+	{
+		IEnumerable<AlephTav?> verses = await _db.GetAlephTav(request.BookID, request.Chapter);
+		await SendAsync(verses.ToList()!);
+	}
+}

--- a/MyHebrewBible/MyHebrewBible/Endpoints/GetAlephTavByBook.cs
+++ b/MyHebrewBible/MyHebrewBible/Endpoints/GetAlephTavByBook.cs
@@ -1,0 +1,27 @@
+namespace MyHebrewBible.Endpoints;
+
+public class GetAlephTavByBookRequest
+{
+	public long BookID { get; set; }
+}
+
+public class GetAlephTavByBook : Endpoint<GetAlephTavByBookRequest, IEnumerable<AlephTavList>>
+{
+	public override void Configure()
+	{
+		Get("/aleptavlist/{bookid:long}");
+		AllowAnonymous();
+	}
+
+	private readonly Repository _db;
+	public GetAlephTavByBook(Repository repository)
+	{
+		_db = repository;
+	}
+
+	public override async Task HandleAsync(GetAlephTavByBookRequest request, CancellationToken ct)
+	{
+		IEnumerable<AlephTavList?> verses = await _db.GetAlephTavByBook(request.BookID);
+		await SendAsync(verses.ToList()!);
+	}
+}

--- a/MyHebrewBible/MyHebrewBible/Endpoints/Repository.cs
+++ b/MyHebrewBible/MyHebrewBible/Endpoints/Repository.cs
@@ -27,6 +27,34 @@ public class Repository
 		return verseList;
 	}
 
+	private const string alephTavSelect = @"
+		SELECT at.ScriptureID, at.Detail, s.BCV, s.BookID, s.Chapter
+		, wp.WordCount, wp.WordEnum, wp.Hebrew1, wp.Hebrew2, wp.Hebrew3 
+		FROM WordPart wp
+		INNER JOIN AlephTav at ON wp.ScriptureID = at.ScriptureID AND wp.WordCount = at.Word
+		INNER JOIN Scripture s ON wp.ScriptureID = s.ID";
+
+	private const string alephTavOrderBy = "ORDER BY at.ScriptureID, Detail";
+
+	public async Task<IEnumerable<AlephTav?>> GetAlephTav(long bookID, long chapter)
+	{
+		using var connection = await _connectionFactory.CreateConnectionAsync();
+		Parms = new DynamicParameters(new { BookId = bookID, Chapter = chapter });
+		var verseList = await connection.QueryAsync<AlephTav>(
+			$"{alephTavSelect} WHERE BookID=@BookId and Chapter=@Chapter {alephTavOrderBy}", Parms);
+		return verseList;
+	}
+
+	public async Task<IEnumerable<AlephTavList?>> GetAlephTavByBook(long bookID)
+	{
+		using var connection = await _connectionFactory.CreateConnectionAsync();
+		Parms = new DynamicParameters(new { BookId = bookID});
+		//string sql = $"{alephTavSelect} WHERE BookID=@BookId {alephTavOrderBy}";
+		var verseList = await connection.QueryAsync<AlephTavList>(
+			$"{alephTavSelect} WHERE BookID=@BookId {alephTavOrderBy}", Parms);
+		return verseList;
+	}
+
 	public async Task<IEnumerable<WordPart?>> GetWordParts(long scriptureID)
 	{
 		using var connection = await _connectionFactory.CreateConnectionAsync();


### PR DESCRIPTION
# Commit | branch: john-041-port-SAT

Ported Standalone Aleph Tav's from my old MHB Core razor pages project

# Screen Shots

![Screen-Shot-AlephTav-1](https://github.com/user-attachments/assets/83ec77db-024c-4c37-b117-5395a0eeece1)

---

![Screen-Shot-AlephTav-2](https://github.com/user-attachments/assets/79c37589-d98d-436b-9b01-3520e660e106)

---

![Screen-Shot-AlephTav-3](https://github.com/user-attachments/assets/9143b9ac-0989-4a79-9860-f155a718077e)

---

# Server (MyHebrewBible)
- Added `AlephTav` and `AlephTavVerse` tables to `MhbSqlite.db`
- Added AlephTav related EndPoints 

# Client (MyHebrewBible.Client)

## Features/AlephTav
These things were added, this is a rough port 1st version thing

```
- Enums/Filter.cs
- AlephTavScripture.es
- AlephTavSummary.es
- Constants.es
- Details.razor
- DetailsVM.es
- Filter.razor
- Index.razor
- Introduction.razor
- PageSummaryAndAnomalies.razor
- SummaryTable.razor
- Table.razor
- TheRockModal.razor
- WordHtmlMinimal.es
```


