### PR TITLE
Fixed bugs for BC and VL

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Components/BookAndChapter.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Components/BookAndChapter.cs
@@ -1,5 +1,4 @@
 ﻿using MyHebrewBible.Client.Enums;
-using MyHebrewBible.Client.Helpers;
 using AlephTavEnums = MyHebrewBible.Client.Features.AlephTav.Enums;
 
 namespace MyHebrewBible.Client.Components;
@@ -25,7 +24,9 @@ public static class Helper
 
 	public static List<AlephTavEnums.ChapterVerse>? GetSatVerseList(BibleBook? bibleBook, int chapter) // Sat=Standalone Aleph Tav 
 	{
-		if (bibleBook <= VerseFacts.LastBookInOT)
+		if (bibleBook is null) { return null;		}
+
+		if (bibleBook.IsHebrewBible)
 		{
 			AlephTavEnums.BookChaptersVerses? bibleBookWithSATs;
 			if (AlephTavEnums.BookChaptersVerses.TryFromValue(bibleBook!.Value, out bibleBookWithSATs))

--- a/MyHebrewBible/MyHebrewBible.Client/Components/MitzvotTable.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Components/MitzvotTable.razor
@@ -42,7 +42,7 @@
 		}
 		catch (Exception ex)
 		{
-			//Logger!.LogError(ex, "{Method}", nameof(OnParametersSetAsync));
+			Logger!.LogError(ex, "{Method}", nameof(OnParametersSetAsync));
 			Toast!.ShowError($"{Global.ToastShowError} {nameof(MitzvotTable)}!{nameof(OnParametersSetAsync)}");
 		}
 		finally

--- a/MyHebrewBible/MyHebrewBible.Client/Enums/Api.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/Api.cs
@@ -11,7 +11,7 @@ public abstract class Api : SmartEnum<Api>
 	{
 		internal const int AlephTavHebrewVerses = 1;
 		internal const int AlephTavKjvVerses = 2;
-		internal const int AlephTavBookChapterWordPartContext = 3; 
+		internal const int AlephTavBookChapterWordPartContext = 3;
 		internal const int AlephTavTriennialWordPartContext = 4;
 		internal const int Article = 5;
 		internal const int ArticleList = 6;
@@ -21,8 +21,9 @@ public abstract class Api : SmartEnum<Api>
 		internal const int VerseList = 10;
 		internal const int VerseListBetweenIds = 11;
 		internal const int WordPartKjv = 12;
-		internal const int WordPartByScriptureId = 13; 
+		internal const int WordPartByScriptureId = 13;
 		internal const int WordPartByStrongs = 14;
+		internal const int BookChapterWithAT = 15;
 	}
 	#endregion
 
@@ -39,8 +40,9 @@ public abstract class Api : SmartEnum<Api>
 	public static readonly Api VerseList = new VerseListSE();
 	public static readonly Api VerseListBetweenIds = new VerseListBetweenIdsSE();
 	public static readonly Api WordPartKjv = new WordPartKjvSE();
-	public static readonly Api WordPartByScriptureId = new WordPartByScriptureIdSE(); 
+	public static readonly Api WordPartByScriptureId = new WordPartByScriptureIdSE();
 	public static readonly Api WordPartByStrongs = new WordPartByStrongsSE();
+	public static readonly Api BookChapterWithAT = new BookChapterWithATSE();
 	#endregion
 
 	private Api(string name, int value) : base(name, value) { } // Constructor
@@ -49,6 +51,7 @@ public abstract class Api : SmartEnum<Api>
 	public abstract string EndPoint { get; }
 	public abstract string Sql { get; }
 	public abstract string SqlOrderBy { get; } // Note: `SqlOrderBy` is only needed if you need,  e.g., a custom `WHERE` clause
+	public abstract string SqlDetail { get; }
 	#endregion
 
 	#region Private Instantiation
@@ -69,6 +72,7 @@ FROM WordPart wp
 		ON wp.ScriptureID = s.Id";
 		public override string SqlOrderBy => " ORDER BY wp.ScriptureID, wp.WordCount";
 		//DECLARE  @ScriptureID int=1
+		public override string SqlDetail => "";
 	}
 
 	private sealed class AlephTavKjvVersesSE : Api
@@ -81,6 +85,7 @@ FROM Scripture s
 	INNER JOIN AlephTavVerse atv ON s.Id=atv.ScriptureID
 ";
 		public override string SqlOrderBy => " ORDER BY s.ID";
+		public override string SqlDetail => "";
 		//DECLARE  @BookId int=1,  @Chapter int=17
 	}
 
@@ -98,6 +103,7 @@ WHERE BookID=@BookId and Chapter=@Chapter
 ORDER BY Id
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
 
 	private sealed class AlephTavTriennialWordPartContextSE : Api
@@ -114,6 +120,7 @@ WHERE TriennialId=@TriennialId
 ORDER BY Id
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
 
 	private sealed class ArticleSE : Api
@@ -130,6 +137,7 @@ LEFT OUTER JOIN Scripture s ON a.PrimaryScriptureId = s.ID
 WHERE a.Id=@Id
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
 
 	private sealed class ArticleListSE : Api
@@ -138,7 +146,7 @@ WHERE a.Id=@Id
 		public override string EndPoint => "/ArticleList/{filter:long}";
 		public override string Sql => @"SELECT Id, Title FROM Article ";
 		public override string SqlOrderBy => " ORDER BY Title";
-
+		public override string SqlDetail => "";
 		/*
 		public abstract string SqlWhere { get; }
 		public override string SqlWhere => ArticleEnums.Filter.WordStudy.Where;
@@ -155,7 +163,9 @@ WHERE a.Id=@Id
 		WHERE BookID=@BookId and Chapter=@Chapter
 		ORDER BY ID";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
+
 
 	private sealed class MitzvahSE : Api
 	{
@@ -169,6 +179,7 @@ WHERE BookId=@BookId
 ORDER BY BegId
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
 
 	private sealed class ParashaSE : Api
@@ -184,6 +195,7 @@ wHERE t.Id = @TriennialId AND s.ID BETWEEN ScriptureID_Beg AND ScriptureID_End
 ORDER BY s.ID
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
 
 	private sealed class VerseListSE : Api
@@ -196,6 +208,7 @@ FROM Scripture
 WHERE BookId=@BookId AND Chapter=@Chapter AND Verse BETWEEN @BegVerse AND @EndVerse
 ORDER BY ID";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 		//DECLARE  @BookId int=1,  @Chapter int=12,  @BegVerse int=2,  @EndVerse int=3
 	}
 
@@ -209,6 +222,7 @@ FROM Scripture
 WHERE ID BETWEEN @BegId AND @EndId
 ORDER BY ID";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 		//DECLARE  @BookId int=1,  @Chapter int=12,  @BegVerse int=2,  @EndVerse int=3
 	}
 
@@ -222,6 +236,7 @@ FROM WordPart
 WHERE ScriptureID=@ScriptureID
 ORDER BY WordCount";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 		//DECLARE  @ScriptureID int=1
 	}
 
@@ -236,6 +251,7 @@ WHERE ScriptureID=@ScriptureID
 ORDER BY WordCount
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
 
 	private sealed class WordPartByStrongsSE : Api
@@ -249,10 +265,37 @@ WHERE ScriptureID=@ScriptureID and Strongs=@Strongs
 ORDER BY WordCount, SegmentCount
 ";
 		public override string SqlOrderBy => "";
+		public override string SqlDetail => "";
 	}
+
+	private sealed class BookChapterWithATSE : Api
+	{
+		public BookChapterWithATSE() : base($"{nameof(Id.BookChapterWithAT)}", Id.BookChapterWithAT) { }
+		public override string EndPoint => "/bookchapterwithat/{bookid:long}/{chapter:long}";
+		public override string Sql => @"
+SELECT ID, BCV, Verse, VerseOffset, KJV, DescH, DescD  
+FROM Scripture
+WHERE BookID=@BookId and Chapter=@Chapter
+ORDER BY ID
+		";
+
+		public override string SqlDetail => @"
+SELECT Id, BCV, BookID, Chapter, Verse
+, ScriptureID, WordCount, SegmentCount, WordEnum
+, Hebrew1, Hebrew2, Hebrew3
+, KjvWord, Strongs, Transliteration, FinalEnum
+--, HasTwo
+FROM vwAlephTavVerseWordPart
+--WHERE BookID=@BookId and Chapter=@Chapter
+WHERE BookID=39 and Chapter=4
+ORDER BY Id	
+		";
+		public override string SqlOrderBy => "";
+	}
+
 
 	#endregion //SE
 
 }
 
-// Ignore Spelling: Descr, bookid, Mitzvah, mitzvot, wordpart, wordpartkjv, scriptureid, verselist, begverse endverse Nav, triennialid, alephtavkjvverse, alephtavhebrewverse, alephtavbookchapterwordpartcontext, alephtavtriennialwordpartcontext, Strongs
+// Ignore Spelling: Descr, bookid, Mitzvah, mitzvot, wordpart, wordpartkjv, scriptureid, bookchapterwithat, verselist, begverse endverse Nav, triennialid, alephtavkjvverse, alephtavhebrewverse, alephtavbookchapterwordpartcontext, alephtavtriennialwordpartcontext, Strongs

--- a/MyHebrewBible/MyHebrewBible.Client/Enums/BibleBook.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/BibleBook.cs
@@ -182,7 +182,11 @@ public abstract class BibleBook : SmartEnum<BibleBook>
 	public abstract BibleBookPrevNext NavigationPrevious(int Chapter);
 	public abstract BibleBookPrevNext NavigationNext(int Chapter);
 
+	//Properties
+	public bool IsHebrewBible => this.Value <= BookChapterFacts.LastBookInOT ? true : false;
+
 	public string Dump => $" {Value}-{Abrv}-{Name}-{BookGroupEnum}";
+
 	#endregion
 
 

--- a/MyHebrewBible/MyHebrewBible.Client/Enums/Constants.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/Constants.cs
@@ -1,26 +1,35 @@
-﻿namespace MyHebrewBible.Client.Helpers;
+﻿namespace MyHebrewBible.Client.Enums;
 
-public static class VerseFacts
+public static class BookChapterFacts
 {
+	/*
 	public const int LargestVerseCountInOneBook = 2461;
 	public const int LastVerseInTaNaCh = 23145;
 	public const int LastVerseInBible = 31102;
-	public const int LastBookInOT = 39;
+	*/
+	public const int LastBookInOT = 39; // used by MyHebrewBible.Client\Enums\BibleBook.cs
+	/*
 	public const int FirstBookInNT = 40;
 	public const int FirstGospel = 40;
 	public const int LastGospel = 44;
-	public const int LastBookInNT = 66;
+
+	public const int FirstBookInOT = 1; // BookEnum.Genesis;
+	public const int LastBookInNT = 66; // BookEnum.Revelation
+	
 	public const int LastChapterInNt = 22;
 	public const int LastChapterId = 1189;
 	public const int FirstChapterId = 1;
 	public const int LargestVerseInAChapter = 176; //Psa 119:176
 	public const int LargestNumberOfChapterInABook = 150; //Psa
 	public const int StrongsLastHebrewNumber = 8674;
-	public const int StrongsLastGreekNumber = 5624;
-}
+	public const int StrongsLastGreekNumber = 5624;	
+	*/
 
-public static class StrongsFacts
-{
+	/*
 	public const int LastHebrewNumber = 8674;
 	public const int LastGreekNumber = 5624;
+	*/
+
 }
+
+//public static class Constants { }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Section/HebrewTable.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/AlephTav/Section/HebrewTable.razor
@@ -47,9 +47,6 @@
 
 </LoadingComponent>
 
-@* @if (BookAndChapter!.BibleBook!.Value > Helpers.VerseFacts.LastBookInOT)   *@
-
-
 @code {
 
 	[Parameter, EditorRequired] public long ScriptureId { get; set; }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Section/HebrewTable.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Section/HebrewTable.razor
@@ -47,9 +47,6 @@
 
 </LoadingComponent>
 
-@* @if (BookAndChapter!.BibleBook!.Value > Helpers.VerseFacts.LastBookInOT)   *@
-
-
 @code {
 
 	[Parameter, EditorRequired] public long ScriptureId { get; set; }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Section/SectionsAT.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Section/SectionsAT.razor
@@ -1,0 +1,32 @@
+﻿@inject ApiClient Api
+@inject ILogger<SectionsAT>? Logger
+@inject IToastService? Toast
+
+@* @using AlephTavEnums = MyHebrewBible.Client.Features.AlephTav.Enums *@
+
+@code {
+	[Parameter, EditorRequired] public BookAndChapter? BookAndChapter { get; set; }
+
+	protected long FocusScriptureId;
+	protected long VerseNumber;
+	protected bool TurnSpinnerOff = false;
+
+	private ICollection<BibleVerseWithAT>? verses = null;
+
+	private void ReturnedVerse(ScriptureIdAndVerseNumber scriptureIdAndVerseNumber)
+	{
+		FocusScriptureId = scriptureIdAndVerseNumber.ScriptureID;
+		VerseNumber = scriptureIdAndVerseNumber.VerseNumber;
+	}
+
+	StrongsAndWordCount? CurrentStrongsAndWordCount = new StrongsAndWordCount(0, 0);
+	private void ReturnedStrongs(StrongsAndWordCount strongsAndWordCount)
+	{
+		CurrentStrongsAndWordCount = strongsAndWordCount;
+	}
+
+	private void ReturnedCloseEvent()
+	{
+		FocusScriptureId = 0;
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Section/SectionsAT_ADD_LATER.txt
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Section/SectionsAT_ADD_LATER.txt
@@ -1,9 +1,4 @@
-﻿@inject ApiClient Api
-@inject ILogger<Sections>? Logger
-@inject IToastService? Toast
-
-@using AlephTavEnums = MyHebrewBible.Client.Features.AlephTav.Enums
-
+﻿
 <LoadingComponent IsLoading="verses==null" TurnSpinnerOff="TurnSpinnerOff">
 
 	@foreach (var item in verses!)
@@ -84,66 +79,3 @@
 	}
 </LoadingComponent>
 
-@code {
-	[Parameter, EditorRequired] public BookAndChapter? BookAndChapter { get; set; }
-
-	protected long FocusScriptureId;
-	protected long VerseNumber;
-
-	private List<AlephTavEnums.ChapterVerse>? SatVerseList = null;
-	private ICollection<AlephTavBookChapterWordPartContext>? SurroundingWords = null;
-
-	protected bool TurnSpinnerOff = false;
-	private ICollection<BibleVerseBC>? verses = null;
-
-	protected override async Task OnParametersSetAsync()
-	{
-		try
-		{
-			//Logger!.LogInformation("{Method}, BookAndChapter: {BookAndChapter}", nameof(OnParametersSetAsync), BookAndChapter);
-			FocusScriptureId = 0;
-			if (BookAndChapter is not null && BookAndChapter!.BibleBook is not null)
-			{
-				verses = await Api!.GetBookChapterAsync((long)BookAndChapter!.BibleBook, (long)BookAndChapter.Chapter);
-				//Logger!.LogInformation("{Method}, verses.Count: {Count}", nameof(OnParametersSetAsync), verses.Count());
-				SatVerseList = MyHebrewBible.Client.Components.Helper.GetSatVerseList(BookAndChapter.BibleBook, BookAndChapter.Chapter);
-				if (SatVerseList is not null)
-				{
-					//Toast!.ShowInfo($"Call GetAlephTavWordPartContextAsync; | B/C {BookAndChapter!.BibleBook}/{BookAndChapter.Chapter}");
-					SurroundingWords = await Api!.GetAlephTavBookChapterWordPartContextAsync((long)BookAndChapter!.BibleBook, (long)BookAndChapter.Chapter);
-					//Toast!.ShowInfo($" SurroundingWords.Count() {SurroundingWords.Count()}");
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			Logger!.LogError(ex, "{Method}", nameof(OnParametersSetAsync));
-			Toast!.ShowError($"{Global.ToastShowError} {nameof(Sections)}!{nameof(OnParametersSetAsync)}");
-		}
-		finally
-		{
-			TurnSpinnerOff = true;
-		}
-
-	}
-
-
-
-	private void ReturnedVerse(ScriptureIdAndVerseNumber scriptureIdAndVerseNumber)
-	{
-		FocusScriptureId = scriptureIdAndVerseNumber.ScriptureID;
-		VerseNumber = scriptureIdAndVerseNumber.VerseNumber;
-	}
-
-	StrongsAndWordCount? CurrentStrongsAndWordCount = new StrongsAndWordCount(0, 0);
-	private void ReturnedStrongs(StrongsAndWordCount strongsAndWordCount)
-	{
-		CurrentStrongsAndWordCount = strongsAndWordCount;
-	}
-
-	private void ReturnedCloseEvent()
-	{
-		FocusScriptureId = 0;
-	}
-
-}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/VerseRange.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Enums/VerseRange.cs
@@ -1,45 +1,7 @@
 ﻿using MyHebrewBible.Client.Enums;
-using AlephTavEnums = MyHebrewBible.Client.Features.AlephTav.Enums;
-using MyHebrewBible.Client.Helpers;
 
 namespace MyHebrewBible.Client.Features.Parasha.Enums;
 
-/* Triennial.cs
-
-public override VerseRange TorahVerse => new VerseRange(BibleBook.Genesis, "2:4-3-24", 35, 80);
-
-public override List<VerseRange> BritVerses => [
-		new VerseRange(BibleBook.John, "1:6-28", 26051, 26073),
-		new VerseRange(BibleBook.Romans, "5:12-21", 28060, 28069),
-		new VerseRange(BibleBook.Hebrews, "11:1-7", 30174, 30180),];
-
-*/
+// See 057-Strongs-Frequency-Analysis\Notes.md re.  `VerseRange.cs` ! `GetSatVerseList()`
 public record VerseRange(BibleBook BibleBook, string ChapterVerse, long	BegId, long EndId);
 
-/*
-ToDo: Not used, should this whole class / record be deleted after `Triennial.cs` is refactored?
-public static class Helper
-{
-	public static List<AlephTavEnums.ChapterVerse>? GetSatVerseList(VerseRange verseRange) // Sat=Standalone Aleph Tav 
-	{
-		if (verseRange.BibleBook <= VerseFacts.LastBookInOT)
-		{
-			AlephTavEnums.BookChaptersVerses? bibleBookWithSATs;
-			if (AlephTavEnums.BookChaptersVerses.TryFromValue(verseRange.BibleBook!.Value, out bibleBookWithSATs))
-			{
-				//return bibleBookWithSATs.Verses!.Where(w => w.Chapter == chapter).ToList();
-				return bibleBookWithSATs.Verses!.Where(w => w.Chapter == 1).ToList();
-			}
-			else
-			{
-				return null;
-			}
-		}
-		else
-		{
-			return null;
-		}
-
-	}
-}
-*/

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Section/HebrewTable.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Section/HebrewTable.razor
@@ -45,9 +45,6 @@
 
 </LoadingComponent>
 
-@* @if (BookAndChapter!.BibleBook!.Value > Helpers.VerseFacts.LastBookInOT)   *@
-
-
 @code {
 
 	[Parameter, EditorRequired] public long ScriptureId { get; set; }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Section/Sections.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Parasha/Section/Sections.razor
@@ -1,4 +1,6 @@
-﻿@using AlephTavEnums = MyHebrewBible.Client.Features.AlephTav.Enums
+﻿@inject ILogger<Sections>? Logger
+
+@using AlephTavEnums = MyHebrewBible.Client.Features.AlephTav.Enums
 
 @foreach (var item in ParashaVerses!.OrderBy(o => o.ID))
 {
@@ -24,10 +26,7 @@
 				</sup>
 			</ParagraphEnd>
 		</ParagraphKjv>
-		if (SurroundingWords is not null)
-		{
-			<ParagraphSAT SurroundingWords="SurroundingWords!.Where(w => w.Verse == item.Verse).ToList()" />
-		}
+		<ParagraphSAT SurroundingWords="SurroundingWords?.Where(w => w.Verse == item.Verse).ToList()" />
 	}
 	else
 	{
@@ -66,6 +65,9 @@
 
 
 @code {
+
+
+
 	[Parameter, EditorRequired] public List<Parasha>? ParashaVerses { get; set; }
 	[Parameter] public List<AlephTavTriennialWordPartContext>? SurroundingWords { get; set; }
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Index.razor
@@ -41,25 +41,24 @@
 }
 else
 {
-	<p> <b>Features\VerseList\Index.razor</b> <code>CurrentBookChapterVerse is not null</code></p>
+	<p> <b>Features\VerseList\Index.razor</b> <code>CurrentBookChapterVerse IS null</code></p>
 }
 
 @if (CurrentBookChapterVerse is not null)
 {
-<LoadingProgress>
-	<div class="mt-5">
-		<br />
-		<Sections BookChapterVerse="CurrentBookChapterVerse" />
-	</div>
-</LoadingProgress>
+	<LoadingProgress>
+		<div class="mt-5">
+			<br />
+			<Sections BookChapterVerse="CurrentBookChapterVerse" />
+		</div>
+	</LoadingProgress>
 }
-
 
 @code {
 	[Parameter, EditorRequired] public int BookId { get; set; }
 	[Parameter, EditorRequired] public int Chapter { get; set; }
 	[Parameter, EditorRequired] public int BegVerse { get; set; }
-	[Parameter, EditorRequired] public int EndVerse { get; set; }
+	[Parameter, EditorRequired] public int EndVerse { get; set; } // currently not referenced
 
 	public Header? CurrentHeader { get; set; }
 	public BookChapterVerse? CurrentBookChapterVerse { get; set; }
@@ -68,25 +67,38 @@ else
 
 	protected string PageTitle => GlobalEnums.BibleBookFormat.BCV(CurrentBookChapterVerse, useAbrv: false);
 
-	protected override void OnParametersSet()
+	//protected override void OnParametersSet()
+	protected override async Task OnParametersSetAsync()
 	{
 		//Logger!.LogInformation("{Method}, Route BCVbVe: {BookId}/{Chapter}/{BegVerse}/{EndVerse}"
 		//	, nameof(OnParametersSet), BookId, Chapter, BegVerse, EndVerse);
 		try
 		{
-			/*
-			Header header = state!.GetHeader();
-			CurrentHeader = new BookAndChapter(BibleBook.FromValue(_state.BibleBookId), _state.Chapter);
-			*/
 			if (BookId == 0 && Chapter == 0) //  && BegVerse == 0 && EndVerse == 0 the first two should be sufficient
 			{
+				//Toast!.ShowSuccess("OnParametersSetAsync | B&C=0");
 				ReNavigateBackToThisPage();
 			}
 			else
 			{
-				CurrentBookChapterVerse = new BookChapterVerse(new BookAndChapter(GlobalEnums.BibleBook.FromValue(BookId), Chapter), BegVerse);
-			}
+				ValidationTuple vt = ValidateRouteParameters();
+				if (vt.IsValid)
+				{
+					CurrentBookChapterVerse = vt.BCV;
+					//Toast!.ShowSuccess("OnParametersSetAsync");
+					await CascadingAppState!.AppState!.VerseListState!.UpdateBCV(
+						new DetailRecord(vt.BCV!.BookAndChapter.BibleBook, vt.BCV.BookAndChapter.Chapter
+							, vt.BCV.Verse, vt.BCV.Verse, "Updated inside OnParametersSetAsync"));
 
+					ReNavigateBackToThisPage();
+				}
+				else
+				{
+					Toast!.ShowWarning(vt.ErrorMessage);
+					ReNavigateBackToThisPage();
+				}
+					
+			}
 		}
 		catch (Exception ex)
 		{
@@ -94,6 +106,37 @@ else
 			Toast!.ShowError($"{Global.ToastShowError} {nameof(Index)}!{nameof(OnParametersSet)}");
 		}
 	}
+
+	private ValidationTuple ValidateRouteParameters()
+	{
+		GlobalEnums.BibleBook? bibleBook;
+		if (GlobalEnums.BibleBook.TryFromValue(BookId, out bibleBook))
+		{
+			if (Chapter >= 1 && Chapter <= bibleBook!.LastChapter)
+			{
+				if ((BegVerse >= 1 && BegVerse <= bibleBook.LastVerses[Chapter - 1]) &&
+						(EndVerse >= 1 && EndVerse <= bibleBook.LastVerses[Chapter - 1]) &&
+						(BegVerse <= EndVerse) )
+				{
+					return new ValidationTuple(true, "", new BookChapterVerse(new BookAndChapter(bibleBook, Chapter), BegVerse));
+				}
+				else
+				{
+					return new ValidationTuple(false, $"Beginning verse {BegVerse} and/or ending verse: {EndVerse} is in valid", new BookChapterVerse(new BookAndChapter(GlobalEnums.BibleBook.Genesis, 1), 1));
+				}
+
+			}
+			else
+			{
+				return new ValidationTuple(false, $"Chapter: {Chapter} is in valid", new BookChapterVerse(new BookAndChapter(GlobalEnums.BibleBook.Genesis, 1), 1));
+			}
+		}
+		else
+		{
+			return new ValidationTuple(false, $"BookId: {BookId} is in valid", new BookChapterVerse(new BookAndChapter(GlobalEnums.BibleBook.Genesis, 1), 1));
+		}
+	}
+
 
 	private void ReNavigateBackToThisPage()
 	{
@@ -111,12 +154,19 @@ else
 		}
 	}
 
-
-	private async Task ReturnedBookChapterVerse(BookChapterVerse vm)
+	//private async Task ReturnedBookChapterVerse(BookChapterVerse bookChapterVerse)
+	private void ReturnedBookChapterVerse(BookChapterVerse bookChapterVerse)
 	{
-		CurrentBookChapterVerse = vm!;
-		await CascadingAppState!.AppState!.VerseListState!.UpdateBCV(
-			new DetailRecord(vm.BookAndChapter.BibleBook, vm.BookAndChapter.Chapter, vm.Verse, vm.Verse, "Just Got Updated"));
+		NavigationManager!.NavigateTo($"verselist/{bookChapterVerse.BookAndChapter.BibleBook!.Value}/{bookChapterVerse.BookAndChapter.Chapter}/{bookChapterVerse.Verse}/{bookChapterVerse.Verse}");
+
+		Toast!.ShowInfo("ReturnedBookChapterVerse");
+		// await CascadingAppState!.AppState!.VerseListState!.UpdateBCV(
+		// 	new DetailRecord(bookChapterVerse.BookAndChapter.BibleBook, bookChapterVerse.BookAndChapter.Chapter, 
+		// 		bookChapterVerse.Verse, bookChapterVerse.Verse, "Updated inside ReturnedBookChapterVerse"));
+
+		CurrentBookChapterVerse = bookChapterVerse;
 	}
-	// Ignore Spelling: bcv
+	// Ignore Spelling: bcv, verselist, bookid, begverse, endverse
+
+
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Section/HebrewTable.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Section/HebrewTable.razor
@@ -47,7 +47,6 @@
 
 </LoadingComponent>
 
-@* @if (BookAndChapter!.BibleBook!.Value > Helpers.VerseFacts.LastBookInOT)   *@
 
 
 @code {

--- a/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Section/Sections.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/Section/Sections.razor
@@ -33,7 +33,7 @@
 					</sup>
 				</ParagraphEnd>
 			</ParagraphKjv>
-			@* <ParagraphSAT SurroundingWords="SurroundingWords!.Where(w => w.Verse == item.Verse).ToList()" /> *@
+			@* <ParagraphSAT SurroundingWords="SurroundingWords?.Where(w => w.Verse == item.Verse).ToList()" /> *@
 		}
 		else
 		{
@@ -82,7 +82,7 @@
 
 	protected override async Task OnParametersSetAsync()
 	{
-		Logger!.LogInformation("{Method}", nameof(OnParametersSetAsync));
+		Logger!.LogInformation("{Method}, BCV: {BookChapterVerse}", nameof(OnParametersSetAsync), BookChapterVerse);
 		FocusScriptureId = 0;
 
 		if (BookChapterVerse is null || BookChapterVerse!.BookAndChapter.BibleBook is null)
@@ -93,11 +93,15 @@
 		{
 			try
 			{
-				await Task.Delay(5);
+				//await Task.Delay(5);
 				verses = await Api!.GetVerseListByBCVAsync((long)BookChapterVerse.BookAndChapter.BibleBook, 
 																										(long)BookChapterVerse.BookAndChapter.Chapter, 
 																										(long)BookChapterVerse.Verse, 
 																										(long)BookChapterVerse.Verse);
+				// if (verses is null || !verses.Any())
+				// {
+				// 	Toast!.ShowWarning($"No verses found; BCV: {BookChapterVerse}");
+				// }
 			}
 			catch (Exception ex)
 			{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/ValidationTuple.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/VerseList/ValidationTuple.cs
@@ -1,0 +1,6 @@
+﻿using MyHebrewBible.Client.Components;
+
+namespace MyHebrewBible.Client.Features.VerseList;
+
+public record ValidationTuple (bool IsValid, string ErrorMessage, BookChapterVerse? BCV);
+

--- a/MyHebrewBible/MyHebrewBible.Client/HealthChecks/BookChapter/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/HealthChecks/BookChapter/Index.razor
@@ -15,6 +15,11 @@
 		<a class="btn btn-primary btn-sm" href="/api/bookchapter/2/20">API BookChapter 2:20</a>
 		<a class="btn btn-primary btn-sm" href="/bookchapter/2/20/Exo-20">BookChapter 2:20 (Exo-20) </a>
 	</div>
+	<div class="card-body">
+		<a class="btn btn-primary btn-sm" href="/api/bookchapterwithat/39/1">API BookChapterWithAT Mal(39):1 [no SAT] </a>
+		<a class="btn btn-primary btn-sm" href="/api/bookchapterwithat/39/4">API BookChapterWithAT Mal(39):4 [with SAT] </a>
+		@* <a class="btn btn-primary btn-sm" href="/bookchapter/2/20/Exo-20">BookChapter 2:20 (Exo-20) </a> *@
+	</div>
 	<p class="card-footer text-center">FOOTER</p>
 </div>
 

--- a/MyHebrewBible/MyHebrewBible.Client/HealthChecks/VerseList/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/HealthChecks/VerseList/Index.razor
@@ -6,18 +6,36 @@
 
 <PageHeader PageEnum="Page.HealthCheckVerseList" />
 
+<h5>Api Calls</h5>
 <div class="d-flex justify-content-start mb-3">
 
 	<div class="p-2 bd-highlight">
 		<ul class="">
-			<li class=""><a class="" href="/api/VerseList/1/2">VerseList/1/2</a></li>
-			<li class=""><a class="" href="/api/VerseList/2/1">VerseList/2/1</a></li>
-			<li class=""><a class="" href="/api/VerseList/1/303">VerseList/1/303</a></li>
+			<li class=""><a class="" href="/api/VerseList/99/1/1/1">VerseList/99/1/1/1</a></li>
+			<li class=""><a class="" href="/api/VerseList/1/99/1/1">VerseList/1/99/1/1</a></li>
+			<li class=""><a class="" href="/api/VerseList/-1/1/1/1">VerseList/-1/1/1/1</a></li>
 			<li class=""><a class="" href="/api/VerseList/">VerseList/</a></li>
+			<li class=""><a class="" href="/api/VerseList/1/2/3/4">VerseList/1/2/3/4</a></li>
 		</ul>
 	</div>
 
+</div>
 
+<h5>Page Calls</h5>
+<div class="card-body px-0">
+	<a href="/VerseList/1/1/1/1">1/1/1/1</a>&nbsp;&nbsp;
+	<a href="/VerseList/99/1/1/1">99/1/1/1</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/99/1/1">1/99/1/1</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/1/99/1">1/1/99/1</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/1/1/99">1/1/1/99</a>&nbsp;&nbsp;
+
+	<a href="/VerseList/1/1/0/0">1/1/0/0</a>&nbsp;&nbsp;
+	<a href="/VerseList/-1/1/1/1/1">-1/1/1/1</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/1/30/30">1/1/30/30</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/1/31/31">1/1/31/31</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/1/32/32">1/1/32/32</a>&nbsp;&nbsp;
+	<a href="/VerseList/1/1/31/30">1/1/31/30</a>&nbsp;&nbsp;
+	<a href="/VerseList">/VerseList</a>&nbsp;&nbsp;
 </div>
 
 

--- a/MyHebrewBible/MyHebrewBible.Client/HttpClient/ApiClient.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/HttpClient/ApiClient.cs
@@ -661,6 +661,93 @@ namespace MyHebrewBible.Client
 
         /// <returns>Success</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<BibleVerseWithAT>> GetBookChapterWithATAsync(long bookid, long chapter)
+        {
+            return GetBookChapterWithATAsync(bookid, chapter, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<BibleVerseWithAT>> GetBookChapterWithATAsync(long bookid, long chapter, System.Threading.CancellationToken cancellationToken)
+        {
+            if (bookid == null)
+                throw new System.ArgumentNullException("bookid");
+
+            if (chapter == null)
+                throw new System.ArgumentNullException("chapter");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/bookchapterwithat/{bookid}/{chapter}"
+                    urlBuilder_.Append("api/bookchapterwithat/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(bookid, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append('/');
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(chapter, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<BibleVerseWithAT>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <returns>Success</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<Mitzvah>> GetMitzvotAsync(long filter)
         {
             return GetMitzvotAsync(filter, System.Threading.CancellationToken.None);
@@ -1670,6 +1757,90 @@ namespace MyHebrewBible.Client
 
         [System.Text.Json.Serialization.JsonPropertyName("DescD")]
         public string DescD { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class BibleVerseWithAT
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("ID")]
+        public long ID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BCV")]
+        public string BCV { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Verse")]
+        public long Verse { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("VerseOffset")]
+        public string VerseOffset { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("KJV")]
+        public string KJV { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("DescH")]
+        public string DescH { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("DescD")]
+        public string DescD { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordPartList")]
+        public System.Collections.Generic.ICollection<WordPart> WordPartList { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.8.0 (NJsonSchema v11.0.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class WordPart
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("Id")]
+        public int Id { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BCV")]
+        public string BCV { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("BookID")]
+        public long BookID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Chapter")]
+        public long Chapter { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Verse")]
+        public long Verse { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("ScriptureID")]
+        public int ScriptureID { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordCount")]
+        public int WordCount { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("SegmentCount")]
+        public int SegmentCount { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("WordEnum")]
+        public int WordEnum { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew1")]
+        public string Hebrew1 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew2")]
+        public string Hebrew2 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Hebrew3")]
+        public string Hebrew3 { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("KjvWord")]
+        public string KjvWord { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Strongs")]
+        public int Strongs { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("Transliteration")]
+        public string Transliteration { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("FinalEnum")]
+        public int? FinalEnum { get; set; }
 
     }
 

--- a/MyHebrewBible/MyHebrewBible.Client/MyHebrewBible.Client.csproj
+++ b/MyHebrewBible/MyHebrewBible.Client/MyHebrewBible.Client.csproj
@@ -9,6 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Features\VerseList\Enums\**" />
+    <Content Remove="Features\VerseList\Enums\**" />
+    <EmbeddedResource Remove="Features\VerseList\Enums\**" />
+    <None Remove="Features\VerseList\Enums\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Ardalis.SmartEnum" Version="8.0.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Blazored.Toast" Version="4.2.1" />
@@ -26,7 +33,6 @@
 
   <ItemGroup>
     <Folder Include="Features\Translations\NGIHR\Enums\" />
-    <Folder Include="Features\VerseList\Enums\" />
   </ItemGroup>
 
 </Project>

--- a/MyHebrewBible/MyHebrewBible/Database/Queries/BookChaptetWithAT.sql
+++ b/MyHebrewBible/MyHebrewBible/Database/Queries/BookChaptetWithAT.sql
@@ -1,0 +1,17 @@
+﻿-- DECLARE @BookId int =39,  @Chapter int=4
+
+SELECT ID, BCV, Verse, VerseOffset, KJV, DescH, DescD  
+FROM Scripture
+--WHERE BookID=@BookId and Chapter=@Chapter
+WHERE BookID=39 and Chapter=4
+ORDER BY ID
+
+SELECT Id, BCV, BookID, Chapter, Verse
+, ScriptureID, WordCount, SegmentCount, WordEnum
+, Hebrew1, Hebrew2, Hebrew3
+, KjvWord, Strongs, Transliteration, FinalEnum
+--, HasTwo
+FROM vwAlephTavVerseWordPart
+--WHERE BookID=@BookId and Chapter=@Chapter
+WHERE BookID=39 and Chapter=4
+ORDER BY Id

--- a/MyHebrewBible/MyHebrewBible/Endpoints/GetBookChapterWithAT.cs
+++ b/MyHebrewBible/MyHebrewBible/Endpoints/GetBookChapterWithAT.cs
@@ -1,0 +1,80 @@
+﻿using MyHebrewBible.Client.Enums;
+
+namespace MyHebrewBible.Endpoints;
+
+public class BookChapterWithATRequest
+{
+	//[BindFrom("amount")]
+	public long BookID { get; set; }
+	public long Chapter { get; set; }
+}
+
+public class GetBookChapterWithAT : Endpoint<BookChapterWithATRequest, IEnumerable<BibleVerseWithAT>>
+{
+	public override void Configure()
+	{
+		Get(Api.BookChapterWithAT.EndPoint);
+		AllowAnonymous();
+	}
+
+	#region DI 
+	private readonly Query _db;
+	private readonly ILogger<GetBookChapterWithAT> _logger;
+	public GetBookChapterWithAT(Query query, ILogger<GetBookChapterWithAT> logger)
+	{
+		_db = query;
+		_logger = logger;
+	}
+	#endregion
+
+	public override async Task HandleAsync(BookChapterWithATRequest request, CancellationToken ct)
+	{
+		_logger.LogDebug("{Method} Get B/C: {BookID}/{Chapter}"
+			, nameof(HandleAsync), request.BookID, request.Chapter);
+		try
+		{
+			IEnumerable<BibleVerseWithAT?> verses = await _db.GetBookChapterWithAT(request.BookID, request.Chapter);
+			_logger.LogDebug($"Retrieved {verses.Count()} verses from the database.");
+			await SendAsync(verses.ToList()!);
+		}
+		catch (Exception ex)
+		{
+			_logger!.LogError(ex, "{Method}", nameof(HandleAsync));
+			throw;
+		}
+	}
+}
+
+public class BibleVerseWithAT
+{
+	public long ID { get; set; }
+	public string? BCV { get; set; }
+	public long Verse { get; set; }
+	public string? VerseOffset { get; set; }
+	public string? KJV { get; set; }
+	public string? DescH { get; set; }
+	public string? DescD { get; set; }
+	public List<WordPart>? WordPartList { get; set; }
+}
+
+public record WordPart
+{
+	public int Id { get; init; }                   // AlephTavVerseWordPart!Id int
+	public string? BCV { get; init; }
+	public long BookID { get; init; }              // Scripture!BookID is bigint
+	public long Chapter { get; init; }             // Scripture!Chapter is bigint
+	public long Verse { get; init; }               // Scripture!Verse is bigint
+	public int ScriptureID { get; init; }          // WordPart!ScriptureID int
+	public int WordCount { get; init; }
+	public int SegmentCount { get; init; }
+	public int WordEnum { get; init; }             // WordPart!WordEnum int
+	public string? Hebrew1 { get; init; }
+	public string? Hebrew2 { get; init; }
+	public string? Hebrew3 { get; init; }
+	public string? KjvWord { get; init; }
+	public int Strongs { get; init; }              // WordPart!Strongs int
+	public string? Transliteration { get; init; }
+	public int? FinalEnum { get; init; }           // WordPart!FinalEnum int
+}
+
+// Ignore Spelling: BCV, Strongs


### PR DESCRIPTION
# Commit | branch: john-057-Bug-Fixes-VL-BC

# BookChapter Bug Fix

### Screen shot bug
- Related file Features\BookChapter\Section\Sections.razor

An unhandled exception occurred when viewing NT BC

![exception-error-occured-when-viewing-BC-with-in-the-NT](https://github.com/user-attachments/assets/d5983d8a-9294-41ec-a1d7-5f4d57dbe9f1)

### wrong null conditional operator
this fixed the problem

![wrong-null-conditional-operator](https://github.com/user-attachments/assets/febdb7fd-b3df-42c4-ad62-b9336626fd2d)


# VerseList Code Fix

# Code Ahead

## Server
### `GetBookChapterWithAT`
Build a LINQ style Query expression that

#### `BibleVerseWithAT.cs`
```csharp
public class BibleVerseWithAT
{
	public long ID { get; set; }
	public string? BCV { get; set; }
	public long Verse { get; set; }
	public string? VerseOffset { get; set; }
	public string? KJV { get; set; }
	public string? DescH { get; set; }
	public string? DescD { get; set; }
	public List<WordPart>? WordPartList { get; set; }
}
```

```csharp
public record WordPart
{
	public int Id { get; init; }                
	public int ScriptureID { get; init; }         
// ...
	public int? FinalEnum { get; init; }          
}
```

### `Query.cs`

#### `GetBookChapterWithAT`
- 	Two Select Statements
- No MARS, the underlying SQLite connection does not support multiple active result sets (Mars)
  - this won't work `connection.QueryMultipleAsync<BibleVerseWithAT>(Api.BookChapterWithAT.Sql, Parms);
- 

```csharp
public async Task<IEnumerable<BibleVerseWithAT?>> GetBookChapterWithAT(long bookID, long chapter)
{
  try
  {
    _logger.LogDebug("{Method} Get B/C: {bookID}/{chapter}", nameof(GetBookChapterWithAT), bookID, chapter);

    using (var connection = await _connectionFactory.CreateConnectionAsync())
    {
      Parms = new DynamicParameters(new { BookId = bookID, Chapter = chapter });
      var wordPart = await connection.QueryAsync<WordPart>(Api.BookChapterWithAT.SqlDetail, Parms);

			// first call the detail record set because it's more likely than not it will be empty.
			// if it is empty, then we can skip the second call.
      if (wordPart is not null && wordPart.Any())
      {
        var sciptureList = await connection.QueryAsync<BibleVerseWithAT>(Api.BookChapterWithAT.Sql, Parms);

        var query =
            from s in sciptureList
            join wp in wordPart
            on s.ID equals wp.ScriptureID into wpGroup
            select new BibleVerseWithAT
            {
              ID = s.ID,
              BCV = s.BCV,
              Verse = s.Verse,
              VerseOffset = s.VerseOffset,
              KJV = s.KJV,
              DescH = s.DescH,
              DescD = s.DescD,
              WordPartList = wpGroup.ToList()
            };
        return query;

        //return sciptureList;
      }
      else
      {
        // the detail record set is empty, so we can skip the second call
        var sciptureList = await connection.QueryAsync<BibleVerseWithAT>(Api.BookChapterWithAT.Sql, Parms);
        return sciptureList;
      }
    }
  }
  catch (Exception ex)
  {
    _logger!.LogError(ex, "{Method} Sql:{Sql}", nameof(GetBookChapterWithAT), Api.BookChapterWithAT.Sql);
    throw;
  }
}
```

#### Api (Client)

```csharp
internal const int BookChapterWithAT = 15;

public static readonly Api BookChapterWithAT = new BookChapterWithATSE();

public abstract string SqlDetail { get; } // This is shmeky


	private sealed class BookChapterWithATSE : Api
	{
		public BookChapterWithATSE() : base($"{nameof(Id.BookChapterWithAT)}", Id.BookChapterWithAT) { }
		public override string EndPoint => "/bookchapterwithat/{bookid:long}/{chapter:long}";
		public override string Sql => @"
SELECT ID, BCV, Verse, VerseOffset, KJV, DescH, DescD  
FROM Scripture
WHERE BookID=@BookId and Chapter=@Chapter
ORDER BY ID
		";

		public override string SqlDetail => @"
SELECT Id, BCV, BookID, Chapter, Verse
, ScriptureID, WordCount, SegmentCount, WordEnum
, Hebrew1, Hebrew2, Hebrew3
, KjvWord, Strongs, Transliteration, FinalEnum
--, HasTwo
FROM vwAlephTavVerseWordPart
--WHERE BookID=@BookId and Chapter=@Chapter
WHERE BookID=39 and Chapter=4
ORDER BY Id	
		";
		public override string SqlOrderBy => "";
	}

}
```

# Other
## Enums/BibleBook (Client)

```
	//Properties
	public bool IsHebrewBible => this.Value <= BookChapterFacts.LastBookInOT ? true : false;

```

- Related, Moved the content Helpers/VerseFacts.cs to /Enums/Constants.cs and then deleted the file

## Parasha (Client)

### `VerseRange.cs`
- Features\Parasha\Enums\
This was cleaned up because I was thinking I was not going to need it because I was going to re-do Triennial CodeGen
Turns out I need it so I removed the notes that were in that file

### `Sections.razor` /Section
like with BookChapter, I was using the wrong null conditional operator

```html
<!--                   This was SurroundingWords! and this was wrong -->
<ParagraphSAT SurroundingWords="SurroundingWords?.Where(w => w.Verse == item.Verse).ToList()" />
```


## VerseList (Client)

### `Index.razor` 
- Bug fixed: the passed in route parameters weren't being respected, only that which was stored in local storage was.

Lot's of changes made, it works but further understanding of how this is supposed to work needs to be thought out

### `Sections.razor` /Section
like with BookChapter, I was using the wrong null conditional operator
the code was commented out, but if I decided to use `ParagraphSAT` it will be correct

```html
<!--                      This was SurroundingWords! and this was wrong -->
@* <ParagraphSAT SurroundingWords="SurroundingWords?.Where(w => w.Verse == item.Verse).ToList()" /> *@

```

### `ValidationTuple.cs`
- Added to test the route parameters

```csharp
using MyHebrewBible.Client.Components;
namespace MyHebrewBible.Client.Features.VerseList;

public record ValidationTuple (bool IsValid, string ErrorMessage, BookChapterVerse? BCV);
```

- Used by `Index.razor` 
```csharp
protected override async Task OnParametersSetAsync()

//...
  else
  {
    ValidationTuple vt = ValidateRouteParameters();
    if (vt.IsValid)
    {
      CurrentBookChapterVerse = vt.BCV;
      await CascadingAppState!.AppState!.VerseListState!.UpdateBCV(
        new DetailRecord(vt.BCV!.BookAndChapter.BibleBook, vt.BCV.BookAndChapter.Chapter
          , vt.BCV.Verse, vt.BCV.Verse, "Updated inside OnParametersSetAsync"));

      ReNavigateBackToThisPage();
    }
    else
//...

```


### HealthChecks/VerseList
- added test for the API and for the Route.

