### PR TITLE
Added console app CopySqliteDB

### DIFF
--- a/CopySqliteDB/Constants.cs
+++ b/CopySqliteDB/Constants.cs
@@ -1,0 +1,6 @@
+﻿public static class Constants
+{
+	public const string Folder = "C:\\Source\\repos\\FastEndpoints\\Mhb-FastEndpoints-Hosted-Blazor-Wasm\\CopySqliteDB\\"; // MhbSqliteBigInt.db\\
+	public const string MhbSqliteBigIntConnectionString = "Data Source=MhbSqliteBigInt.db;Version=3;";
+	public const string MhbSqliteConnectionString = "Data Source=MhbSqlite.db;Version=3;";	
+}

--- a/CopySqliteDB/CopySqliteDB.csproj
+++ b/CopySqliteDB/CopySqliteDB.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TableDefinitions\" />
+  </ItemGroup>
+
+</Project>

--- a/CopySqliteDB/Program.cs
+++ b/CopySqliteDB/Program.cs
@@ -1,0 +1,211 @@
+﻿using Spectre.Console;
+using System.Data.SQLite;
+using Dapper;
+using System.Text;
+
+internal class Program
+{
+	record ProgressInfo(double BookTaskIncrease);
+
+	class AnsiConsoleProgress
+	{
+		private readonly ProgressTask _taskBook;
+		private readonly object _consoleLock = new object();
+
+		public AnsiConsoleProgress(ProgressTask taskBook)
+		{
+			_taskBook = taskBook;
+		}
+
+		public void ReportProgress(ProgressInfo info)
+		{
+			lock (_consoleLock)
+			{
+				_taskBook.Increment(info.BookTaskIncrease);
+			}
+		}
+	}
+
+	public static async Task Main(string[] args)
+	{
+		AnsiConsole.MarkupLine("[blue]Start CopySqliteDB [/]");
+		AnsiConsole.WriteLine();
+
+		Stats stats = new Stats();
+
+		try
+		{
+			await AnsiConsole.Progress()
+			.StartAsync(async ctx =>
+			{
+				var task1 = ctx.AddTask("[green]Processing CopySqliteDB[/]");
+				var ansiProgress = new AnsiConsoleProgress(task1);
+				var progress = new Progress<ProgressInfo>(ansiProgress.ReportProgress);
+				await ProcessDatabase(progress, stats);
+			});
+		}
+		catch (Exception ex)
+		{
+			AnsiConsole.WriteLine();
+			AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+			AnsiConsole.WriteLine();
+		}
+		finally
+		{
+			PrintStats(stats);
+			AnsiConsole.Write(
+				new FigletText("Finished")
+				.Centered()
+				.Color(Color.Aqua));
+		}
+
+	}
+
+	private static void PrintStats(Stats stats)
+	{
+		var grid = new Grid();
+		grid.AddColumn();
+		grid.AddColumn();
+
+		// Add header row 
+		grid.AddRow(new Text[]{
+			new Text("Rows Copied", new Style(Color.Red, Color.Black)).Centered(),  //.LeftJustified(),
+			new Text("Table Name", new Style(Color.Blue, Color.Black)).RightJustified()
+		});
+
+		// Add content row 
+		grid.AddRow(new Text[]{
+			new Text(stats.RowsCopied.ToString()).Centered(),
+			new Text(stats.TableName!.ToString()).Centered(),
+		});
+
+		AnsiConsole.WriteLine();
+		AnsiConsole.Write(grid);
+		AnsiConsole.WriteLine();
+	}
+
+
+	private static async Task ProcessDatabase(IProgress<ProgressInfo> progress, Stats stats)
+	{
+		string tableName = "";
+		int rowsCopied = 0;
+		string readConnectionString = $"Data Source={Constants.Folder}MhbSqliteBigInt.db;Version=3;";
+		string writeConnectionString = $"Data Source={Constants.Folder}MhbSqlite.db;Version=3;";
+
+		using (var readConnection = new SQLiteConnection(readConnectionString))
+		using (var writeConnection = new SQLiteConnection(writeConnectionString))
+		{
+			await readConnection.OpenAsync();
+			await writeConnection.OpenAsync();
+
+			using (var transaction = writeConnection.BeginTransaction())
+			{
+				try
+				{
+					await writeConnection.ExecuteAsync($"ATTACH DATABASE '{Constants.Folder}MhbSqliteBigInt.db' AS SourceDb");
+
+					/*
+					tableName = "Scripture";	
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					transaction.Commit();
+
+					stats.TableName = tableName;	
+					stats.RowsCopied = rowsCopied;
+
+
+					tableName = "WordPart";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					transaction.Commit();
+
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					progress.Report(new ProgressInfo(.20));
+
+					tableName = "WordPartKjv";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					transaction.Commit();
+
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					*/
+
+					tableName = "AlephTavVerse";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					progress.Report(new ProgressInfo(.10));
+
+					tableName = "AlephTavVerseWordPart";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					progress.Report(new ProgressInfo(.10));
+
+					tableName = "Article";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					progress.Report(new ProgressInfo(.10));
+
+					tableName = "JotAndTittle";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					progress.Report(new ProgressInfo(.10));
+
+					tableName = "Mitzvot";
+					rowsCopied = await writeConnection.ExecuteAsync(@$"
+                        INSERT INTO {tableName}
+                        SELECT * FROM SourceDb.{tableName}
+                    ");
+					stats.TableName = tableName;
+					stats.RowsCopied = rowsCopied;
+					progress.Report(new ProgressInfo(.10));
+
+
+					transaction.Commit();
+
+				}
+				catch (Exception ex)
+				{
+					//transaction.Rollback();
+					AnsiConsole.WriteLine();
+					AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+					AnsiConsole.WriteLine();
+				}
+				finally
+				{
+					await writeConnection.ExecuteAsync($"DETACH DATABASE SourceDb");
+				}
+				
+			}
+		}
+	}
+
+
+
+	/*
+
+	*/
+}

--- a/CopySqliteDB/Stats.cs
+++ b/CopySqliteDB/Stats.cs
@@ -1,0 +1,5 @@
+﻿public class Stats
+{
+	public int RowsCopied { get; set; } = 0;
+	public string? TableName { get; set; } = "";
+}

--- a/CopySqliteDB/TableDefinitions/AlephTavVerse.sql
+++ b/CopySqliteDB/TableDefinitions/AlephTavVerse.sql
@@ -1,0 +1,8 @@
+﻿CREATE TABLE [AlephTavVerse] (
+  [ScriptureID] int NOT NULL
+, [Verse] nvarchar(50) NOT NULL COLLATE NOCASE
+, [CommentsMD] nvarchar(500) NULL COLLATE NOCASE
+, [HasTwo] int NOT NULL
+, CONSTRAINT [sqlite_autoindex_AlephTavVerse_1] PRIMARY KEY ([ScriptureID])
+, CONSTRAINT [FK_AlephTavVerse_0_0] FOREIGN KEY ([ScriptureID]) REFERENCES [Scripture] ([ID]) ON DELETE NO ACTION ON UPDATE NO ACTION
+);

--- a/CopySqliteDB/TableDefinitions/AlephTavVerseWordPart.sql
+++ b/CopySqliteDB/TableDefinitions/AlephTavVerseWordPart.sql
@@ -1,0 +1,15 @@
+﻿CREATE TABLE [AlephTavVerseWordPart] (
+  [Id] int NOT NULL PRIMARY KEY
+, [ScriptureID] int NOT NULL
+, [WordCount] int NOT NULL
+/*
+, CONSTRAINT [FK_AlephTavVerseWordPart_0_0] FOREIGN KEY ([ScriptureID], [WordCount]) REFERENCES [WordPart] ([ScriptureID], [WordCount]) ON DELETE NO ACTION ON UPDATE NO ACTION
+, CONSTRAINT [FK_AlephTavVerseWordPart_1_0] FOREIGN KEY ([ScriptureID]) REFERENCES [Scripture] ([ID]) ON DELETE NO ACTION ON UPDATE NO ACTION
+*/
+);
+/*
+CREATE TRIGGER [fki_AlephTavVerseWordPart_ScriptureID_Scripture_ID] BEFORE Insert ON [AlephTavVerseWordPart] FOR EACH ROW BEGIN SELECT RAISE(ROLLBACK, 'Insert on table AlephTavVerseWordPart violates foreign key constraint FK_AlephTavVerseWordPart_Scripture') WHERE (SELECT [ID] FROM Scripture WHERE  [ID] = NEW.[ScriptureID]) IS NULL; END;
+CREATE TRIGGER [fku_AlephTavVerseWordPart_ScriptureID_Scripture_ID] BEFORE Update ON [AlephTavVerseWordPart] FOR EACH ROW BEGIN SELECT RAISE(ROLLBACK, 'Update on table AlephTavVerseWordPart violates foreign key constraint FK_AlephTavVerseWordPart_Scripture') WHERE (SELECT [ID] FROM Scripture WHERE  [ID] = NEW.[ScriptureID]) IS NULL; END;
+CREATE TRIGGER [fki_AlephTavVerseWordPart_ScriptureID_WordPart_ScriptureID] BEFORE Insert ON [AlephTavVerseWordPart] FOR EACH ROW BEGIN SELECT RAISE(ROLLBACK, 'Insert on table AlephTavVerseWordPart violates foreign key constraint FK_AlephTavVerseWordPart_WordPart') WHERE (SELECT [ScriptureID], [WordCount] FROM WordPart WHERE  [ScriptureID] = NEW.[ScriptureID] AND [WordCount] = NEW.[WordCount]) IS NULL; END;
+CREATE TRIGGER [fku_AlephTavVerseWordPart_ScriptureID_WordPart_ScriptureID] BEFORE Update ON [AlephTavVerseWordPart] FOR EACH ROW BEGIN SELECT RAISE(ROLLBACK, 'Update on table AlephTavVerseWordPart violates foreign key constraint FK_AlephTavVerseWordPart_WordPart') WHERE (SELECT [ScriptureID], [WordCount] FROM WordPart WHERE  [ScriptureID] = NEW.[ScriptureID] AND [WordCount] = NEW.[WordCount]) IS NULL; END;
+*/

--- a/CopySqliteDB/TableDefinitions/Article.sql
+++ b/CopySqliteDB/TableDefinitions/Article.sql
@@ -1,0 +1,20 @@
+﻿CREATE TABLE [Article] (
+  [Id] INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+, [FileNameNoExt] nvarchar(255) NOT NULL COLLATE NOCASE
+, [Title] nvarchar(255) NOT NULL COLLATE NOCASE
+, [Uri] nvarchar(255) NULL COLLATE NOCASE
+, [Details] ntext NULL
+, [DetailsMD] ntext NULL
+, [PrimaryScriptureId] int DEFAULT (31192) NOT NULL
+, [CreateDate] datetime NOT NULL
+, [DocBlobID] int NULL
+, [PdfBlobID] int NULL
+, [IsPlaceHolder] bit NOT NULL
+, [IsFavorite] bit NOT NULL
+, [ExtraVerses] int DEFAULT (0) NOT NULL
+, [IsWordStudy] bit NOT NULL
+, [IsParasha] bit NOT NULL
+, CONSTRAINT [FK_Article_0_0] FOREIGN KEY ([PrimaryScriptureId]) REFERENCES [Scripture] ([ID]) ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+CREATE TRIGGER [fki_Article_PrimaryScriptureId_Scripture_ID] BEFORE Insert ON [Article] FOR EACH ROW BEGIN SELECT RAISE(ROLLBACK, 'Insert on table Article violates foreign key constraint FK_Article_Scripture') WHERE (SELECT [ID] FROM Scripture WHERE  [ID] = NEW.[PrimaryScriptureId]) IS NULL; END;
+CREATE TRIGGER [fku_Article_PrimaryScriptureId_Scripture_ID] BEFORE Update ON [Article] FOR EACH ROW BEGIN SELECT RAISE(ROLLBACK, 'Update on table Article violates foreign key constraint FK_Article_Scripture') WHERE (SELECT [ID] FROM Scripture WHERE  [ID] = NEW.[PrimaryScriptureId]) IS NULL; END;

--- a/CopySqliteDB/TableDefinitions/JotAndTittle.sql
+++ b/CopySqliteDB/TableDefinitions/JotAndTittle.sql
@@ -1,0 +1,8 @@
+﻿CREATE TABLE [JotAndTittle] (
+  [Id] int NOT NULL PRIMARY KEY
+, [ScriptureID] int NULL
+, [Verse] text NULL
+, [DescrHtml] text NULL
+, [Notes] text NULL
+);
+

--- a/CopySqliteDB/TableDefinitions/Mitzvot.sql
+++ b/CopySqliteDB/TableDefinitions/Mitzvot.sql
@@ -1,0 +1,10 @@
+﻿CREATE TABLE [Mitzvot] (
+  [Id] int NOT NULL PRIMARY KEY
+, [Detail] int NULL
+, [BegId] int NULL
+, [EndId] int NULL
+, [Verse] text NULL
+, [Descr] text NULL
+, [BookId] int NULL
+, [BookAbrv] text NULL
+);

--- a/CopySqliteDB/TableDefinitions/Scripture.sql
+++ b/CopySqliteDB/TableDefinitions/Scripture.sql
@@ -1,0 +1,15 @@
+﻿CREATE TABLE [Scripture] (
+  [Id] int NOT NULL
+, [BCV] text NOT NULL
+, [BookID] int NOT NULL
+, [Chapter] int NOT NULL
+, [Verse] int NOT NULL
+, [KJV] text NOT NULL
+, [VerseOffset] text NULL
+, [DescH] text NULL
+, [DescD] text NULL
+, [DescHSlug] text NULL
+, CONSTRAINT [sqlite_master_PK_Scripture] PRIMARY KEY ([Id])
+);
+CREATE UNIQUE INDEX [Scripture_sqlite_autoindex_Scripture_2] ON [Scripture] ([BCV] ASC);
+CREATE UNIQUE INDEX [Scripture_sqlite_autoindex_Scripture_1] ON [Scripture] ([Id] ASC);

--- a/CopySqliteDB/TableDefinitions/ShabbatWeek.sql
+++ b/CopySqliteDB/TableDefinitions/ShabbatWeek.sql
@@ -1,0 +1,4 @@
+﻿CREATE TABLE [ShabbatWeek] (
+  [Id] int NULL
+, [ShabbatDate] text NULL
+);

--- a/CopySqliteDB/TableDefinitions/Triennial.sql
+++ b/CopySqliteDB/TableDefinitions/Triennial.sql
@@ -1,0 +1,12 @@
+﻿CREATE TABLE [Triennial] (
+  [Id] int NOT NULL
+, [SectionId] tinyint NOT NULL
+, [RowCnt] tinyint NOT NULL
+, [BookId] int NOT NULL
+, [AnnualId] int NOT NULL
+, [VerseRange] nvarchar(50) NOT NULL COLLATE NOCASE
+, [ScriptureID_Beg] int NOT NULL
+, [ScriptureID_End] int NOT NULL
+, [RowIdentity] INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+CREATE UNIQUE INDEX [Triennial_Triennial_IX_Triennial_Unique] ON [Triennial] ([Id] ASC,[SectionId] ASC,[RowCnt] ASC);

--- a/CopySqliteDB/TableDefinitions/WordPart.sql
+++ b/CopySqliteDB/TableDefinitions/WordPart.sql
@@ -1,0 +1,14 @@
+﻿CREATE TABLE [WordPart] (
+  [ScriptureID] int NOT NULL
+, [WordCount] int NOT NULL
+, [SegmentCount] int NOT NULL
+, [WordEnum] int NULL
+, [Hebrew1] nvarchar(30) NOT NULL COLLATE NOCASE
+, [Hebrew2] nvarchar(30) NULL COLLATE NOCASE
+, [Hebrew3] nvarchar(30) NULL COLLATE NOCASE
+, [KjvWord] nvarchar(100) NULL COLLATE NOCASE
+, [Strongs] int NULL
+, [Transliteration] nvarchar(30) NULL COLLATE NOCASE
+, [FinalEnum] int NULL
+, CONSTRAINT [sqlite_autoindex_WordPart_1] PRIMARY KEY ([ScriptureID],[WordCount])
+);

--- a/CopySqliteDB/TableDefinitions/WordPartKjv.sql
+++ b/CopySqliteDB/TableDefinitions/WordPartKjv.sql
@@ -1,0 +1,7 @@
+﻿CREATE TABLE [WordPartKjv] (
+  [ScriptureID] int NOT NULL
+, [WordCount] tinyint NOT NULL
+, [Strongs] int NULL
+, [Word] nvarchar(70) NULL COLLATE NOCASE
+, CONSTRAINT [sqlite_autoindex_WordPartKjv_1] PRIMARY KEY ([ScriptureID],[WordCount])
+);

--- a/CopySqliteDB/ViewDefinitions/vwAlephTavBookChapterWordPart.sql
+++ b/CopySqliteDB/ViewDefinitions/vwAlephTavBookChapterWordPart.sql
@@ -1,0 +1,50 @@
+﻿CREATE VIEW vwAlephTavBookChapterWordPart 
+AS  
+ 
+/* 
+SELECT *  
+FROM vwAlephTavBookChapterWordPart 
+WHERE BookID=2 AND Chapter=20 
+ORDER BY Id 
+ 
+ 
+ 
+SELECT  
+at.Verse 
+, at.HasTwo 
+, atwp.* 
+FROM AlephTavVerse at 
+  INNER JOIN vwAlephTavBookChapterWordPart atwp 
+    ON at.ScriptureID=atwp.ScriptureID 
+WHERE at.ScriptureID=1 
+--WHERE BookID=1 AND Chapter=14 
+ORDER BY Id 
+ 
+SELECT * FROM vwAlephTavBookChapterWordPart  
+WHERE BookID=1 AND Chapter=2 
+ORDER BY Id 
+ 
+ 
+SELECT * FROM vwAlephTavBookChapterWordPart  
+WHERE BookID=1 AND Chapter=14 
+ORDER BY Id 
+ 
+SELECT Id, BCV, BookID, Chapter 
+, ScriptureID, WordCount, SegmentCount, WordEnum 
+, Hebrew1, Hebrew2, Hebrew3 
+, KjvWord, Strongs, Transliteration, FinalEnum 
+FROM vwAlephTavBookChapterWordPart 
+ORDER BY Id 
+ 
+--DROP VIEW vwAlephTavBookChapterWordPart 
+ 
+*/ 
+ 
+SELECT  
+atwp.Id, s.BCV, s.BookID, s.Chapter, s.Verse 
+, wp.ScriptureID, wp.WordCount, wp.SegmentCount, wp.WordEnum, wp.Hebrew1, wp.Hebrew2, wp.Hebrew3, wp.KjvWord, wp.Strongs, wp.Transliteration, wp.FinalEnum 
+FROM WordPart wp 
+  INNER JOIN AlephTavVerseWordPart atwp 
+    ON wp.ScriptureID=atwp.ScriptureID AND wp.WordCount=atwp.WordCount 
+  INNER JOIN Scripture s  
+    ON atwp.ScriptureID = s.Id;

--- a/CopySqliteDB/ViewDefinitions/vwAlephTavTriennialWordPart.sql
+++ b/CopySqliteDB/ViewDefinitions/vwAlephTavTriennialWordPart.sql
@@ -1,0 +1,17 @@
+﻿CREATE VIEW vwAlephTavTriennialWordPart 
+AS  
+ 
+/* 
+ 
+SELECT *  
+FROM vwAlephTavTriennialWordPart 
+--WHERE TriennialId=1  
+WHERE TriennialId=8 
+ORDER BY Id 
+ 
+*/ 
+ 
+SELECT t.Id AS TriennialId, t.VerseRange AS TriennialVerseRange, atwp.* 
+FROM vwAlephTavVerseWordPart atwp 
+CROSS JOIN  Triennial t 
+WHERE atwp.ScriptureID BETWEEN t.ScriptureID_Beg AND t.ScriptureID_End;

--- a/CopySqliteDB/ViewDefinitions/vwParashaTableOfContents.sql
+++ b/CopySqliteDB/ViewDefinitions/vwParashaTableOfContents.sql
@@ -1,0 +1,15 @@
+﻿CREATE VIEW vwParashaTableOfContents  
+AS   
+  
+/*  
+SELECT *   
+FROM vwParashaTableOfContents  
+WHERE Id=15  
+ORDER BY SectionId, RowCnt  
+ 
+*/  
+  
+SELECT SectionId  
+, ROW_NUMBER() OVER (PARTITION BY Id, SectionId ORDER BY SectionId, RowCnt) AS GroupCount  
+, BookId, AnnualId, VerseRange, ScriptureID_Beg, ScriptureID_End, Id, RowIdentity, RowCnt  
+FROM Triennial;

--- a/CopySqliteDB/ViewDefinitions/vwTableRowCount.sql
+++ b/CopySqliteDB/ViewDefinitions/vwTableRowCount.sql
@@ -1,0 +1,18 @@
+﻿CREATE VIEW vwTableRowCount
+AS   
+  
+/*  
+SELECT * FROM vwTableRowCount  
+
+DROP VIEW vwTableRowCount
+
+*/  
+
+SELECT
+(SELECT count(*) FROM AlephTavVerse)           AS AlephTavVerseCnt,          --    612
+(SELECT count(*) FROM AlephTavVerseWordPart)   AS AlephTavVerseWordPartCnt,  --  3,165
+(SELECT count(*) FROM Article)                 AS ArticleCnt,                --    630
+(SELECT count(*) FROM JotAndTittle)            AS JotAndTittleCnt,           --     74
+(SELECT count(*) FROM Mitzvot)                 AS MitzvotCnt,                --    645  
+(SELECT count(*) FROM WordPart)                AS WordPartCnt,               -- 304,574
+(SELECT count(*) FROM WordPartKjv)             AS WordPartKjvCnt;            -- 322,350

--- a/CopySqliteDB/ViewDefinitions/vwUtilScripts.sql
+++ b/CopySqliteDB/ViewDefinitions/vwUtilScripts.sql
@@ -1,0 +1,6 @@
+﻿/*
+VACUUM;
+
+SELECT name FROM sqlite_master WHERE type = 'index';
+
+*/

--- a/MyHebrewBible.sln
+++ b/MyHebrewBible.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CopySqliteDB", "CopySqliteDB\CopySqliteDB.csproj", "{B5115591-8161-470D-93AC-FDA7015EE2A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{65C793AE-6DD4-4D31-ABFC-3465A28CC1C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65C793AE-6DD4-4D31-ABFC-3465A28CC1C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65C793AE-6DD4-4D31-ABFC-3465A28CC1C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5115591-8161-470D-93AC-FDA7015EE2A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5115591-8161-470D-93AC-FDA7015EE2A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5115591-8161-470D-93AC-FDA7015EE2A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5115591-8161-470D-93AC-FDA7015EE2A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MyHebrewBible/MyHebrewBible.Client/Enums/Api.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Enums/Api.cs
@@ -112,6 +112,7 @@ WHERE a.Id=@Id
 		*/
 	}
 
+	// update vwAlephTavVerseWordPart
 	private sealed class BookChapterWithATSE : Api
 	{
 		public BookChapterWithATSE() : base($"{nameof(Id.BookChapterWithAT)}", Id.BookChapterWithAT) { }


### PR DESCRIPTION
# Commit | branch: john-063-add-CopySqliteDB-console

Added console app CopySqliteDB

The console App copied the data from the old formatted tables (with bitint) and inserted them into the new database

#### Steps
1. `MhbSqliteBigInt.db` was the source and `MhbSqlite.db` was the destination 
2. Before running the app, `MhbSqliteBigInt.db` was gotten from the copying the production version and pasted it to the console app root folder (and renamed `MhbSqliteBigInt.db)
3. `MhbSqlite.db` was created from scratch an external tool
4. Before running the app, the table `CREATE` definitions were run from the EricEJ tool
5. Created the same views over (`CREATE VIEW...`)
   - renamed vwAlephTavVerseWordPart to vwAlephTavBookChapterWordPart
   - this will cause further changes in the next branch

## Solution Explorer with changes
- Note, I already zipped up and deleted `MhbSqliteBigInt.db`

![Solution-Explorer](https://github.com/user-attachments/assets/778d60c5-5435-4f9e-9f1d-9be35a0d64b2)
