### PR TITLE
Backup before Split-TensAndOnesButtons-by-Phase

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/BookChapterVerse.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/BookChapterVerse.cs
@@ -4,3 +4,11 @@ namespace MyHebrewBible.Client.Features.BookChapter.Toolbar.NumberPad;
 
 public record BookChapterVerse(BibleBook? BibleBook, int Chapter, int Verse);
 
+public static class BookChapterVerseHelper
+{
+	public static string Dump(BookChapterVerse? BCV)
+	{
+		return $"{BCV!.BibleBook!.Abrv} {BCV.Chapter}:{BCV.Verse}";
+	}
+}
+// Ignore Spelling: BCV	

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ButtonWrapper.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ButtonWrapper.razor
@@ -6,13 +6,10 @@
 @inject ILogger<ButtonWrapper>? Logger
 @inject IToastService? Toast
 
-@* <p>Chapter: @StepState!.Chapter | Verse: @StepState!.Verse</p> *@
-
-<PlaceWrapper StepState="StepState" IsDebug=true>
+<PlaceWrapper StepState="StepState" IsDebug=IsDebug>
 
 	<TitleContent>
 		@GetTitleContent(@StepState!.Step!.Phase, StepState!.Chapter, StepState!.PlaceValueRec!.Mask)
-		@* , StepState!.Verse *@
 	</TitleContent>
 
 	<HundredsColumn>
@@ -26,9 +23,19 @@
 			<ColumnHeading Place="Enums.Place.Tens" />
 			@if (StepState!.Step!.Place == Place.Tens)
 			{
-				<TensAndOnesButtons CurrentStepState="StepState"
+				@if (StepState!.Step!.Phase == Phase.Chapter)
+				{
+					@* ChapterTensAndOnesButtons StepState="StepState" ??? *@
+				}
+				else
+				{
+					@* VerseTensAndOnesButtons  StepState="StepState" ??? *@
+				}
+
+				<TensAndOnesButtons StepState="StepState"
 														LastTensPlaceIsWhole=@GetLastTensPlaceIsWhole()
-														OnNumberSelected="ReturnedNumber" />
+														OnNumberSelected="ReturnedNumber"
+														OnNumberFinished="ReturnedFinalNumber" />
 			}
 			else
 			{
@@ -48,9 +55,10 @@
 			{
 				@if (StepState!.Step!.Place == Place.Ones)
 				{
-					<TensAndOnesButtons CurrentStepState="StepState"
+					<TensAndOnesButtons StepState="StepState"
 															LastTensPlaceIsWhole=@GetLastTensPlaceIsWhole()
-															OnNumberSelected="ReturnedNumber" />
+															OnNumberSelected="ReturnedNumber"
+															OnNumberFinished="ReturnedFinalNumber" />
 				}
 				else
 				{
@@ -61,9 +69,8 @@
 	</OnesColumn>
 
 	<FooterDebugContent>
-		<p class="text-center mt-3">
-			@GetPVR(StepState!.PlaceValueRec!, StepState!.Phase, StepState.LastChapter, StepState.LastVerse)
-		</p>
+		<p class="text-center mt-3 mb-1">@StepState!.Dump()</p>
+		<p class="text-center mt-1">@StepState!.Dump2()</p>
 		<p>
 			<div class="d-flex justify-content-between">
 				<div class="@GetPadding()">
@@ -79,11 +86,11 @@
 
 	<Footer>
 		<div class=" mt-2 mb-1">
-
+			@* StepState!.Phase *@
 			<div class="d-flex justify-content-center py-2">
 				<button id="backspace" @onclick="() => ButtonClick()"
-								type="button" title="@StepState!.Phase" class="btn btn-primary btn-sm @BackSpaceDisable">
-					<i class="fas fa-backspace"></i> Step @StepState!.Phase
+								type="button" title="@StepState!.Step!.Phase" class="btn btn-primary btn-sm @BackSpaceDisable">
+					<i class="fas fa-backspace"></i> Step @StepState!.Step!.Phase
 				</button>
 			</div>
 		</div>
@@ -91,69 +98,104 @@
 
 </PlaceWrapper>
 
-
 @code {
 	[Parameter, EditorRequired] public GlobalEnums.BibleBook? BibleBook { get; set; }
 	[Parameter, EditorRequired] public EventCallback<BookChapterVerse> OnBCVSelected { get; set; }
 
-	protected int SelectedVerse = 0; // ToDo: are you going to use this or not.
+	private const bool IsDebug = true; // ToDo: remove this when done debugging
 
+	protected int SelectedVerse = 0; // ToDo: are you going to use this or not.
 	protected StepState? StepState { get; set; }
 
 	protected override void OnParametersSet()
 	{
-		StepState = new StepState(BibleBook);
+		//StepState = new StepState(BibleBook);
+		StepState = new StepState(BibleBook, Logger!);
 	}
 
 	private void OnHundredNumberSelected(int number)
 	{
-		Logger!.LogInformation("{Method}, number: {number}", nameof(OnHundredNumberSelected), number);
-		StepState!.ChangeCurrentStep(StepState!.Step!.DirectionForward, number);
+		//Logger!.LogInformation("{Method}, number: {number}", nameof(OnHundredNumberSelected), number);
+		StepState!.UpdatePlaceValueRecForHundreds(number);
+		StepState!.SetNextStepNoPhaseChange();
 	}
 
-	//private void ReturnedNumber(ReturnedNumberVM vm)
-	private async Task ReturnedNumber(ReturnedNumberVM vm)
+
+	private void ReturnedNumber(ReturnedNumberNotFinishedVM vm)
 	{
-		// Logger!.LogInformation("{Method}, ReturnedNumberVM: {ReturnedNumberVM}, Chapter: {Chapter}"
-		// , nameof(ReturnedNumber), vm, StepState!.Chapter);
+		Logger!.LogInformation("{Method}, VM: {VM}", nameof(ReturnedNumber), vm);
 
-		string before = StepState!.Step!.Name;
-		StepState!.ChangeCurrentStep(StepState!.Step!.DirectionForward, vm.Number);
-
-		// Logger!.LogInformation("{Method}, Before/After {BeforeAfter}"
-		// , nameof(ReturnedNumber), $"B/A: {before}/{StepState!.Step!.Name}");
-
-		if (vm.Finished)
+		if (vm.SkipChapterOnes)
 		{
-			await Task.Delay(500);  // ToDo: comment this out in production
-			StepState!.PlaceValueRec = StepState!.PlaceValueRec! with { Ones = vm.Number };
-			int verse = PlaceValueRecHelper.Combine(StepState.PlaceValueRec!);
-			verse = PlaceValueRecHelper.Combine(StepState.PlaceValueRec!);
+			Logger!.LogWarning("... SkipChapterOnes is True");
+			StepState!.UpdatePlaceValueRecForTens(vm.Number); // e.g. Gen 50
+			StepState!.UpdateOnesPlaceValueRecAndSetChapter(0);
 
-			// 	Logger!.LogInformation("{Method}, Call Combine(), PlaceValueRec: {PlaceValueRec}, Verse: {Verse}"
-			// , nameof(ReturnedNumber), StepState!.PlaceValueRec, StepState.Verse);
-
-			// Logger!.LogInformation("{Method}, BibleBook: {BibleBook}, C/V {Chapter}/{Verse}"
-			// , nameof(ReturnedNumber), BibleBook!.Name, StepState!.Chapter, StepState.Verse);  //, verse
-
-			Toast!.ShowWarning($"{BibleBook!.Abrv} {StepState!.Chapter}:{verse}"); // {verse}
-
-			await OnBCVSelected.InvokeAsync(new BookChapterVerse(BibleBook, StepState!.Chapter, verse)); // , verse
+			StepState!.SetLastVerse();
+			StepState!.SetNextStepForSecondPhase();
+			StepState!.LoadPlaceValueRecForVerse();
+		}
+		else // (!vm.SkipChapterOnes)
+		{
+			if (StepState!.Step!.Place == Enums.Place.Tens)
+			{
+				Logger!.LogWarning("... Place is Tens");
+				StepState!.UpdatePlaceValueRecForTens(vm.Number);
+				StepState!.SetNextStepNoPhaseChange();
+			}
+			else
+			{
+				Logger!.LogWarning("... Place is NOT Tens, it's: {Place}", StepState!.Step!.Place);
+				StepState!.UpdateOnesPlaceValueRecAndSetChapter(vm.Number);
+				StepState!.SetLastVerse();              // bibleBook!.LastVerses[chapter - 1];
+				StepState!.SetNextStepForSecondPhase(); // depends on LastVerse
+				StepState!.LoadPlaceValueRecForVerse(); // depends on LastVerse
+			}
 		}
 	}
 
-	//<ResetButton Place="Place" OnPlaceSelected="ReturnedPlace" />
-	//[Parameter, EditorRequired] public EventCallback<Place> OnPlaceSelected { get; set; }
+	private void ReturnedFinalNumber(ReturnedNumberFinishedVM vm)
+	{
+		Logger!.LogInformation("{Method}, VM: {VM}", nameof(ReturnedFinalNumber), vm);
+
+		if (!vm.SkipingVerseOnes) // Normal Path
+		{
+			StepState!.UpdatePlaceValueRecForOnes(vm.Number);
+		}
+		else  // vm.SkipingVerseOnes == true
+		{
+			StepState!.UpdatePlaceValueRecForTens(vm.Number);  // e.g. Ezr 2:7
+			StepState!.UpdatePlaceValueRecForOnes(0);
+		}
+
+		int verse = StepState!.GetVerse();
+		BookChapterVerse BCV = new BookChapterVerse(BibleBook, StepState!.Chapter, verse);
+		Logger!.LogInformation("{Method}, TSC.Finished , B/C/V {bcv}", nameof(ReturnedFinalNumber), BCV);
+		Toast!.ShowInfo($"{BookChapterVerseHelper.Dump(BCV)}");
+		OnBCVSelected.InvokeAsync(BCV);
+	}
 
 	private int GetLastTensPlaceIsWhole()
 	{
+		Logger!.LogInformation("{Method}, PlaceValueRec: {PlaceValueRec}"
+		, nameof(GetLastTensPlaceIsWhole), StepState!.PlaceValueRec!);
+
 		if (StepState!.PlaceValueRec!.IsWhole)
 		{
 			// If PlaceValueRec.IsWhole is true than PlaceValueRec.Ten must have an int
-			return (int)StepState!.PlaceValueRec.Tens!;
+			if (StepState!.PlaceValueRec.Tens is not null)
+			{
+				return (int)StepState!.PlaceValueRec.Tens!;
+			}
+			else { return 0; }
 		}
 		else { return 0; }
 	}
+
+	//private int GetLastTensPlaceIsWhole()	{	}
+
+	//<ResetButton Place="Place" OnPlaceSelected="ReturnedPlace" />
+	//[Parameter, EditorRequired] public EventCallback<Place> OnPlaceSelected { get; set; }
 
 	protected string? BackSpaceDisable = " disabled";
 	private void ButtonClick()
@@ -171,6 +213,7 @@
 		sb.Append(" <h6 class='text-center py-2'> ")
 			.Append("Chapter: ")
 			.AppendIfElse(chapter == 0, $"<u>{mask}</u>", $"<b>{chapter}</b> {check}").Append("<br />")
+			//.AppendIfElse(chapter == 0, $"<u>{mask}</u>", $"<b>{chapter}</b> {check}").AppendIf(IsDebug, " of []").Append("<br />")
 			.AppendIfElse(chapter == 0, $"<span class='fw-lighter'>Verse: ___</span>", $"Verse: <u>{mask}</u>")
 			// .AppendIf(verse != 0, $"<b>{verse} {check}</b>")
 			.Append("</h6>");
@@ -178,13 +221,6 @@
 		return (MarkupString)sb.ToString();
 	}
 
-	protected string GetPVR(PlaceValueRec placeValueRec, Enums.Phase? phase, int lastChapter, int lastVerse)
-	{
-		string s = PlaceValueRecHelper.Concatenate(placeValueRec);
-		if (lastChapter != 0) { s += ", LC: " + lastChapter; }
-		if (lastVerse != 0) { s += ", LV: " + lastVerse; }
-		return s;
-	}
 
 	protected string GetPadding()
 	{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/Helper.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/Helper.cs
@@ -50,6 +50,7 @@ public class Helper
 
 	#region ToDo Create Common Modulus Function
 	// Called (7 times) by StepState!LoadPlaceValueRecForVerse
+
 	public static int GetPlace(Enums.Place place, int lastVerse)
 	{
 		if (place == Enums.Place.Hundreds)
@@ -60,14 +61,12 @@ public class Helper
 		{
 			if (place == Enums.Place.Tens)
 			{
-				//return lastVerse >= 10 ? lastVerse / 10 : 0;
 				return lastVerse >= 10 ? (lastVerse / 10) % 10 : 0;
 			}
 			else // PlaceEnums.Place.Ones
 			{
 				if (lastVerse >= 100)
 				{
-					//return lastVerse % 100;
 					return lastVerse % 10;
 				}
 				else
@@ -83,7 +82,6 @@ public class Helper
 				}
 			}
 		}
-
 	}
 	#endregion
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/PlaceSkeleton.txt
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/PlaceSkeleton.txt
@@ -1,0 +1,2 @@
+﻿
+Rename PlaceWrapper.razor to PlaceSkeleton.razor

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/PlaceValueRecHelper.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/PlaceValueRecHelper.cs
@@ -31,7 +31,8 @@ public class PlaceValueRecHelper // static
 
 	public static string Concatenate(PlaceValueRec place)
 	{
-		return $"Hun:{(place.Hundreds is null ? "X" : place.Hundreds)}, Tens:{(place.Tens is null ? "X" : place.Tens)}, Ones:{place.Ones}"; // , W:{(place.IsWhole ? "T" : "F")}
+		return $"Hun:{(place.Hundreds is null ? "X" : place.Hundreds)}, Tens:{(place.Tens is null ? "X" : place.Tens)}, Ones:{place.Ones}"; 
+		// , W:{(place.IsWhole ? "T" : "F")}
 	}
 
 	private static int EvalNullValues(int? hundredsOrTens)

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ReturnedNumberFinishedVM.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ReturnedNumberFinishedVM.cs
@@ -1,0 +1,4 @@
+﻿namespace MyHebrewBible.Client.Features.BookChapter.Toolbar.NumberPad;
+
+
+public record ReturnedNumberFinishedVM(int Number, bool SkipingVerseOnes);

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ReturnedNumberNotFinishedVM.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ReturnedNumberNotFinishedVM.cs
@@ -1,0 +1,3 @@
+﻿namespace MyHebrewBible.Client.Features.BookChapter.Toolbar.NumberPad;
+
+public record ReturnedNumberNotFinishedVM(int Number, bool SkipChapterOnes); 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ReturnedNumberVM.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ReturnedNumberVM.cs
@@ -1,4 +1,0 @@
-﻿namespace MyHebrewBible.Client.Features.BookChapter.Toolbar.NumberPad;
-
-//ToDo: change out Finished with Enums.Directions
-public record ReturnedNumberVM(int Number, bool Finished);

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/StepState.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/StepState.cs
@@ -1,19 +1,21 @@
 ﻿using MyHebrewBible.Client.Enums;
 using MyHebrewBible.Client.Features.BookChapter.Toolbar.NumberPad.Enums;
+//using Microsoft.Extensions.Logging;
 
 namespace MyHebrewBible.Client.Features.BookChapter.Toolbar.NumberPad;
 
 public class StepState
 {
+	//private readonly ILogger<StepState> Logger; // _logger
+	private readonly ILogger<ButtonWrapper> Logger; // _logger
 
-/*  ToDo: how to add a logger   */
-
-	public StepState(BibleBook? bibleBook)
+	public StepState(BibleBook? bibleBook, ILogger<ButtonWrapper> logger)  //, ILogger<StepState> logger
 	{
 		BibleBook = bibleBook;
+		Logger = logger;
 		LoadPlaceValueRecForChapter();
 		Chapter = 0;
-		Phase = Enums.Phase.Chapter;
+		//Phase = Enums.Phase.Chapter;
 		HundredPlaceIsVisible = bibleBook!.ChapterHundreds > 0;
 	}
 
@@ -21,7 +23,7 @@ public class StepState
 
 	public int Chapter { get; set; }
 	public Step? Step { get; set; }
-	public Phase? Phase { get; set; }
+	//public Phase? Phase { get; set; } // Use StepState.Step.Place
 	public PlaceValueRec? PlaceValueRec; //{ get; set; } 
 	public bool HundredPlaceIsVisible { get; set; } //
 	public int LastChapter = 0;
@@ -49,14 +51,66 @@ public class StepState
 		LastChapter = BibleBook.LastChapter;
 	}
 
-	private static string GetPlaceMask(int count)
+
+	#region Commands
+
+	public void UpdatePlaceValueRecForHundreds(int number)
 	{
-		return new string('X', count); //  PlaceValueRec!.Count
+		PlaceValueRec = PlaceValueRec! with { Hundreds = number, Mask = $"{number}XX" };
 	}
 
-	private void LoadPlaceValueRecForVerse()
+	public void UpdatePlaceValueRecForTens(int number)
 	{
-		if (LastVerse >= 100)  
+		PlaceValueRec = PlaceValueRec! with { Tens = number, Mask = $"{PlaceValueRec.Hundreds}{number}X" };
+	}
+	public void UpdateOnesPlaceValueRecAndSetChapter(int onesNumber)
+	{
+		UpdatePlaceValueRecForOnes(onesNumber);
+		SetChapter();
+	}
+
+	public void UpdatePlaceValueRecForOnes(int number)
+	{
+		PlaceValueRec = PlaceValueRec! with { Ones = number, Mask = "X" };
+	}
+
+	private void SetChapter() => Chapter = PlaceValueRecHelper.Combine(PlaceValueRec!);
+
+	public int LastVerse = 0;  // private int LastVerse = 0;
+	public void SetLastVerse()
+	{
+		/*	
+		LastVerse =  bibleBook!.LastVerses[chapter - 1];
+		*/
+		LastVerse = Helper.GetLastVerse(BibleBook, Chapter); 
+		Logger!.LogInformation("{Method}, LastVerse: {LastVerse}", nameof(SetLastVerse), LastVerse);
+	}
+
+	public void SetNextStepForSecondPhase()
+	{
+		if (LastVerse >= 100)
+		{
+			Step = Step.VerseHundred;
+		}
+		else
+		{
+			if (LastVerse >= 10)
+			{
+				Step = Step.VerseTen;
+			}
+			else
+			{
+				Step = Step.VerseOne;
+			}
+		}
+
+		Logger!.LogInformation("{Method}, LastVerse: {LastVerse}, new Step: {Step}"
+			, nameof(SetNextStepForSecondPhase), LastVerse, Step.Name);
+	}
+	
+	public void LoadPlaceValueRecForVerse()
+	{
+		if (LastVerse >= 100)
 		{
 			PlaceValueRec = new PlaceValueRec(
 				Helper.GetPlace(Place.Hundreds, LastVerse),
@@ -66,7 +120,7 @@ public class StepState
 		}
 		else
 		{
-			if (LastVerse >= 10)  
+			if (LastVerse >= 10)
 			{
 				PlaceValueRec = new PlaceValueRec(
 					null,
@@ -83,16 +137,80 @@ public class StepState
 					Helper.GetLastVerseIsWhole(LastVerse), "X");
 			}
 		}
-
+		//SetNextStepForSecondPhase();
 	}
 
-	public int LastVerse = 0;
+
+
+	public int GetVerse()
+	{
+		return PlaceValueRecHelper.Combine(PlaceValueRec!);
+	}
+
+	public void SetNextStepNoPhaseChange()
+	{
+		Step = Step.FromValue(Step!.Value + 1);
+	}
+
+
+	/*
+	public void SetStep(Enums.TensSpecialCase tensSpecialCase)
+	{
+		if (tensSpecialCase == TensSpecialCase.SkipChapterOnes)
+		{
+			Step = Step.FromValue(Step!.Value + 1);
+		}
+
+		if (tensSpecialCase == TensSpecialCase.SkipVerseOnes)
+		{
+		if (LastVerse >= 100) { Step = Step.VerseHundred; }
+		else if (LastVerse >= 10) { Step = Step.VerseTen; }
+		else { Step = Step.VerseOne; }
+		}
+		if (tensSpecialCase == TensSpecialCase.Finished) //None
+		{
+
+		}
+	}
+	*/
+
+	#endregion
+
+	public string Dump()
+	{
+		//return $"Step: {Step?.Name}, Phase: {Phase}, PlaceValueRec: {PlaceValueRec?.Mask}, Chapter: {Chapter}, LastVerse: {LastVerse}";
+		//string s = PlaceValueRecHelper.Concatenate(PlaceValueRec!);
+		//return s;
+		return PlaceValueRecHelper.Concatenate(PlaceValueRec!);
+	}
+
+	public string Dump2()
+	{
+		string s = "";
+
+		if (Step!.Phase == Phase.Chapter)
+		{
+			if (LastChapter != 0) { s += "LC: " + LastChapter; }
+		}
+
+		if (Step!.Phase == Phase.Verse)
+		{
+			if (LastVerse != 0) { s += "LV: " + LastVerse; }
+		}
+																
+		s += $", IsWhole: {(PlaceValueRec!.IsWhole ? "T" : "F")} "; 
+
+
+		return s;
+	}
+
+	/*
 	public void ChangeCurrentStep(Direction? newDirection, int number = 0)
 	{
 		switch (newDirection)
 		{
 			case Direction.GoToNextStep:
-				if (Step == Enums.Step.ChapterHundred || Step == Enums.Step.VerseHundred)
+				if (Step == Enums.Step.ChapterHundred || Step == Enums.Step.VerseHundred)  //if (Step.Place == Enums.Place.Tens)
 				{
 					PlaceValueRec = PlaceValueRec! with { Hundreds = number, Mask=$"{number}XX" };
 				}
@@ -141,6 +259,12 @@ public class StepState
 				break;
 		}
 	}
+	*/
 
-
+	/*
+	private static string GetPlaceMask(int count)
+	{
+		return new string('X', count); //  PlaceValueRec!.Count
+	}
+	*/
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/TensAndOnesButtons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/TensAndOnesButtons.razor
@@ -29,59 +29,93 @@
 </div>
 
 @code {
-	[Parameter, EditorRequired] public StepState? CurrentStepState { get; set; }
-	[Parameter, EditorRequired] public int LastTensPlaceIsWhole { get; set; }
-	[Parameter, EditorRequired] public EventCallback<ReturnedNumberVM> OnNumberSelected { get; set; }
+	[Parameter, EditorRequired] public StepState? StepState { get; set; }
+	[Parameter, EditorRequired] public int LastTensPlaceIsWhole { get; set; } // If 0 then like being null
+	[Parameter, EditorRequired] public EventCallback<ReturnedNumberNotFinishedVM> OnNumberSelected { get; set; }
+	[Parameter, EditorRequired] public EventCallback<ReturnedNumberFinishedVM> OnNumberFinished { get; set; }
+
+	// private int VerseTensSelected = 0;
+	// if (VerseTensSelected == 0 && StepState!.Step!.Phase == Enums.Phase.Verse) { VerseTensSelected = number;	}
+	
+	private int LastVerse = 0;
+	//private int LastTensPlace = 0; 
+
+	private int one = 0;
+	protected override void OnParametersSet() 
+	{
+		if (StepState!.PlaceValueRec!.IsWhole)
+		{
+			one = 9;
+		}
+		else
+		{
+			one = StepState!.PlaceValueRec!.Ones;
+		}
+		//LastTensPlace = 
+		LastVerse = StepState.LastVerse;
+
+		Logger!.LogInformation("{Method}, one: {one}, Step.Name: {Step.Name}, LastTensPlaceIsWhole: {LastTensPlaceIsWhole}"
+		, nameof(OnParametersSet), one, StepState!.Step!.Name, LastTensPlaceIsWhole);
+	}
 
 	protected string GetButtonClass(int number)
 	{
-		@if (CurrentStepState!.Step!.Place == Enums.Place.Tens)
+		@if (StepState!.Step!.Place == Enums.Place.Tens)
 		{
-			if (number <= CurrentStepState!.PlaceValueRec!.Tens)
-			{
-				if (number == LastTensPlaceIsWhole)
-				{
-					return $"btn {Helper.GetButtonColor(LastTensPlaceIsWhole)} {Helper.GetDefaultButtonClass()}";
-				}
-				else
-				{
-					return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
-				}
-			}
-			else
-			{
-				return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
-			}
+			return GetTensPlaceButtonClass(number);
 		}
-		else // (CurrentStepState!.Step!.Place == Enums.Place.Ones)
+		else // Place == Enums.Place.Ones
 		{
-			int one = 0;
+			return GetOnesPlaceButtonClass(number);
+		}
+	}
 
-			if (CurrentStepState!.PlaceValueRec!.IsWhole)
+	private string GetTensPlaceButtonClass(int number)
+	{
+		if (number <= StepState!.PlaceValueRec!.Tens)
+		{
+			if (number == LastTensPlaceIsWhole)
 			{
-				one = 9;
+				return $"btn {Helper.GetButtonColor(LastTensPlaceIsWhole)} {Helper.GetDefaultButtonClass()}";
 			}
 			else
-			{
-				one = CurrentStepState!.PlaceValueRec!.Ones;
-			}
-
-			if (number <= one)
 			{
 				return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
 			}
-			else
-			{
-				return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
-			}
+		}
+		else
+		{
+			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
+		}
+	}
 
+	private string GetOnesPlaceButtonClass(int number)
+	{
+		if (number <= one)
+		{
+			return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
+		}
+		else
+		{
+			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
 		}
 
+		/*
+		if (number <= StepState!.PlaceValueRec!.Ones) {	return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";	}
+		else {	return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";	}
+
+		int one = 0;
+		if (StepState!.PlaceValueRec!.IsWhole) { 	one = 9; }
+		else { one = StepState!.PlaceValueRec!.Ones;	}
+
+		if (number <= one) {	return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}"; }
+		else { return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";	}
+		*/
 	}
 
 	protected string GetZeroButtonClass()
 	{
-		if (PlaceValueRecHelper.OnesPlaceZeroButtonIsDisabled(CurrentStepState!.PlaceValueRec!))
+		if (PlaceValueRecHelper.OnesPlaceZeroButtonIsDisabled(StepState!.PlaceValueRec!))
 		{
 			return $"btn {Helper.GetDisabledColor()} disabled {Helper.GetDefaultButtonClass()}";
 		}
@@ -93,28 +127,42 @@
 
 	private void ButtonClick(int number)
 	{
-		//Logger!.LogInformation("{Method}, number: {number}", nameof(ButtonClick), number);
-		if (CurrentStepState!.Step == Enums.Step.VerseOne)
+		Logger!.LogInformation("{Method}, number: {number}, Step.Name: {Step.Name}, LastTensPlaceIsWhole: {LastTensPlaceIsWhole}"
+			, nameof(ButtonClick), number, StepState!.Step!.Name, LastTensPlaceIsWhole);
+
+		if ((StepState!.Step == Enums.Step.VerseOne) |
+				(number > 0 && number == LastTensPlaceIsWhole && StepState!.Step!.Phase == Enums.Phase.Verse))
 		{
-			OnNumberSelected.InvokeAsync(new ReturnedNumberVM(number, true));
-		}
-		else // Enums.Step.VerseTen
-		{
-			if (number == LastTensPlaceIsWhole)
+			if (StepState!.Step == Enums.Step.VerseOne)
 			{
-				//ToDo: Finish this
-				OnNumberSelected.InvokeAsync(new ReturnedNumberVM(number, false)); // Direction.GoToSecondPhase
+				Logger!.LogInformation("... FinishedVM, SkipingVerseOnes: false");
+				OnNumberFinished.InvokeAsync(new ReturnedNumberFinishedVM(number, SkipingVerseOnes: false));
 			}
 			else
 			{
-			OnNumberSelected.InvokeAsync(new ReturnedNumberVM(number, false));
+				Logger!.LogInformation("... FinishedVM, SkipingVerseOnes: true");
+				OnNumberFinished.InvokeAsync(new ReturnedNumberFinishedVM(number, SkipingVerseOnes: true));
+			}
+		}
+		else
+		{
+			if ((StepState!.Step!.Phase == Enums.Phase.Chapter) &&
+					(number > 0 && number == LastTensPlaceIsWhole))  // e.g. Gen 50
+			{
+				Logger!.LogInformation("...NOT FinishedVM, SkipChapterOnes: true");
+				OnNumberSelected.InvokeAsync(new ReturnedNumberNotFinishedVM(number, SkipChapterOnes: true));
+			}
+			else
+			{
+				Logger!.LogInformation("...NOT FinishedVM, SkipChapterOnes: false");
+				OnNumberSelected.InvokeAsync(new ReturnedNumberNotFinishedVM(number, SkipChapterOnes: false));
 			}
 		}
 	}
 
 	private string GetId(int number)
 	{
-		return $"{CurrentStepState!.Step!.PlaceShortName}-{number}";
+		return $"{StepState!.Step!.PlaceShortName}-{number}";
 	}
 
 }

--- a/MyHebrewBible/MyHebrewBible.Client/HealthChecks/BookChapter/ChaptersAndTheirLastVerses.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/HealthChecks/BookChapter/ChaptersAndTheirLastVerses.razor
@@ -1,0 +1,48 @@
+﻿@using MyHebrewBible.Client.Enums
+
+<div class="card mt-4 mb-3 border-warning">
+	<div class="card-header">
+		<h4 class="card-title text-center">Chapters and their LastVerses</h4>
+	</div>
+
+	<div class="card-body">
+		@foreach (var chapter in @BibleBook.List.ToList().OrderBy(o => o.Value))
+		{
+			<h5 class="mt-4 mb-1">@chapter.Abrv: @chapter.LastChapter chapters</h5>
+
+			<table class="table table-bordered">
+				<thead>
+					<tr class="text-center">
+						<th></th>
+						@for (int i = 1; i <= 10; i++)
+						{
+							<th>@i</th>
+						}
+					</tr>
+				</thead>
+				<tbody>
+					@for (int i = 0; i < chapter.LastVerses.Count(); i += 10)
+					{
+						<tr class="text-center">
+							<td>@((i / 10))</td>
+							@for (int j = 0; j < 10; j++)
+							{
+								if (i + j < chapter.LastVerses.Count())
+								{
+									<td>@chapter.LastVerses[i + j]</td>
+								}
+								else
+								{
+									<td></td>
+								}
+							}
+						</tr>
+					}
+				</tbody>
+			</table>
+		}
+	</div>
+</div>
+
+@code {
+}

--- a/MyHebrewBible/MyHebrewBible.Client/HealthChecks/BookChapter/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/HealthChecks/BookChapter/Index.razor
@@ -6,6 +6,9 @@
 
 <PageHeader PageEnum="Page.HealthCheckBibleBook" />
 
+<ChaptersAndTheirLastVerses />	
+
+
 <div class="card mb-3 border-success">
 	<div class="card-header">
 		<h4 class="card-title text-center">Test some API Calls</h4>


### PR DESCRIPTION
I'm having a hard time wrapping my head around how to finish this feature. I'm thinking that if I splitting the the `TensAndOnesButtons.razor` component into the two separate phases (Chapter and Verse) it will bring clarity what needs to be done.

### Split TensAndOnesButtons; see comments
![Split-TensAndOnesButtons-by-Phase](https://github.com/user-attachments/assets/c930eec0-52eb-4ec0-a1a5-08b233ab2362)


### GitHub Folder
![GitHub-Backup](https://github.com/user-attachments/assets/812f0478-150f-4da5-8c63-f4c04b2dfe28)

### Gen 42 | Chapter Phase
![Gen-42-01-Phase-Chapter](https://github.com/user-attachments/assets/a5a68321-3cc7-4b42-9b4e-3c9d075558c2)

### Gen 42 | Verse Phase
![Gen-42-02-Phase-Verse](https://github.com/user-attachments/assets/aa5d0720-f125-4d9b-a7c4-1bfcb7d9e79d)
