### PR TITLE
Bug fix GetOnesPlaceButtonClass, got menu show debug working

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Enums/MenuItem.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Enums/MenuItem.cs
@@ -37,7 +37,7 @@ public abstract class MenuItem : SmartEnum<MenuItem>
 	private sealed class ShowDebugPickerSE : MenuItem
 	{
 		public ShowDebugPickerSE() : base(nameof(ShowDebugPicker), Id.ShowDebugPicker) { }
-		public override string Title => "Show Debug";
+		public override string Title => "** Dynamically Set **"; // Show Debug or Hide Debug
 	}
 
 	private sealed class InstructionsSE : MenuItem

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Index.razor
@@ -12,13 +12,9 @@
 
 <PageTitle>@PageTitle</PageTitle>
 
-
-@* OnBookAndChapterSelected="ReturnedBookAndChapter": Called by  <PreviousButton> & <NextButton> *@
-
 <Navbar CurrentBookAndChapter="CurrentBookAndChapter"
 				OnBookAndChapterSelected="ReturnedBookAndChapter"
 				CurrentBCV="CurrentBCV"
-				ShowDebugPicker="ShowDebugPicker"
 				OnBCVSelected="ReturnedBCV"
 				OnMenuItemSelected="ReturnedMenuItem" />
 
@@ -143,29 +139,18 @@
 
 
 	protected bool ShowPageInstructionsModal = false;
-	protected bool ShowDebugPicker = false;
 
-	//private async Task ReturnedMenuItem(Enums.MenuItem item)
-	private void ReturnedMenuItem(Enums.MenuItem item)
+	private async Task ReturnedMenuItem(Enums.MenuItem item)
 	{
 		if (item == Enums.MenuItem.Instructions)
 		{
 			ShowPageInstructionsModal = !ShowPageInstructionsModal;
 		}
-		else
+		if (item == Enums.MenuItem.ShowDebugPicker)
 		{
-			if (item == Enums.MenuItem.ShowDebugPicker)
-			{
-				ShowDebugPicker = !ShowDebugPicker;
-				// //if (Toolbar == Constants.ToolbarNumericPad)	{ Toolbar = Constants.ToolbarDynamicButtons; }
-				// //else {Toolbar = Constants.ToolbarNumericPad;}
-				// await State!.AppState!.BookChapterState!.UpdateToolbar(Toolbar);
-			}
-			else
-			{
-				//
-			}
+			await State!.AppState!.BookChapterState!.TogglePickerDebug();
 		}
+		//else 	{  	}
 	}
 
 	// Ignore Spelling: bc, rec

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/State.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/State.cs
@@ -19,7 +19,7 @@ public class State
 	#endregion
 
 	private const string KeyACVId = "bc-abrv-chapter-verse-id";
-	private const string KeyToolbar = "bc-toolbar";
+	private const string KeyPickerDebug = "bc-picker-debug";
 	private bool _isInitialized;
 	private void NotifyStateHasChanged() => OnChange?.Invoke();
 	public event Action? OnChange;
@@ -27,12 +27,8 @@ public class State
 	private AbrvChapterVerse _DefaultAbrvChapterVerse = new("Gen", 1, 1, true, 0); //"Gen", 1, 1, 1);
 	private AbrvChapterVerse? _AbrvChapterVerse = new("Gen", 1, 1, true, 0);  //"Gen", 1, 1, 1);
 
-	//public const string ToolbarNumericPad = "numeric-pad";
-	//public const string ToolbarDynamicButtons = "dynamic-buttons";
-	//private string _DefaultToolbar = ToolbarNumericPad;
-
-	//private Enums.MenuItem _DefaultMenuItem = Enums.MenuItem.ShowDebugPicker;
-	//private Enums.MenuItem _MenuItem; 
+	private bool _DefaultKeyPickerDebug = false;
+	private bool _PickerDebug = false;
 
 	public async Task Initialize()
 	{
@@ -49,17 +45,17 @@ public class State
 				await UpdateACV(_DefaultAbrvChapterVerse);
 			}
 
-			//_MenuItem = await localStorage!.GetItemAsync<string>(KeyToolbar) ?? _DefaultMenuItem;
-			//if (!String.IsNullOrEmpty(_MenuItem))
-			//{
-			//	await UpdateToolbar(_MenuItem);
-			//}
-			//else
-			//{
-			//	_MenuItem = _DefaultMenuItem;
-			//	await UpdateToolbar(_DefaultMenuItem);
-			//}
-
+			var pd = await localStorage!.GetItemAsync<bool?>(KeyPickerDebug);
+			if (pd is not null)
+			{
+				_PickerDebug = pd.Value;
+				//await TogglePickerDebug();
+			}
+			else
+			{
+				_PickerDebug = _DefaultKeyPickerDebug;
+				await TogglePickerDebug();
+			}
 
 
 			_isInitialized = true;
@@ -82,17 +78,16 @@ public class State
 	}
 
 
-	//public Enums.MenuItem GetShowDebugPicker()
-	//{
-	//	return _MenuItem!;
-	//}
+	public bool GetPickerDebug()
+	{
+		return _PickerDebug!;
+	}
 
-	//public async Task UpdateToolbar(Enums.MenuItem showDebugPicker)
-	//{
-	//	await localStorage!.SetItemAsync(KeyToolbar, showDebugPicker);
-	//	_MenuItem = showDebugPicker;
-	//	NotifyStateHasChanged();
-	//}
-
+	public async Task TogglePickerDebug()
+	{
+		_PickerDebug = !_PickerDebug;
+		await localStorage!.SetItemAsync(KeyPickerDebug, _PickerDebug);
+		NotifyStateHasChanged();
+	}
 }
 // Ignore Spelling: ctor, DI, Abrv, brv, BCV, ACV, bc, toolbar

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/ConfigureDropdown.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/ConfigureDropdown.razor
@@ -10,7 +10,7 @@
 			<li class="dropdown-item">
 				<button @onclick="@(e => ButtonClick(item))"
 				type="button" class="btn btn-outline-primary">
-					<span class="@headerColor">@item.Title</span>
+					<span class="@headerColor">@GetButtonText(@item)</span>
 				</button>
 			</li>
 		}
@@ -20,10 +20,25 @@
 
 @code {
 	[Parameter] public EventCallback<Enums.MenuItem> OnMenuItemSelected { get; set; }
-	
+	[CascadingParameter] public CascadingAppState? State { get; set; }
+
 	string buttonColor => BtnColors.Primary;
 	string headerColor => TextColors.Success;
-	
+	private string? ButtonText;
+
+	private string GetButtonText(Enums.MenuItem menuItem)
+	{
+		if (menuItem == Enums.MenuItem.Instructions)
+		{
+			return menuItem.Title;
+		}
+		else // it's ShowDebugPicker
+		{
+			bool isDebug = State!.AppState!.BookChapterState!.GetPickerDebug();
+			return isDebug ? "Hide Debug" : "Show Debug";	
+		}
+	}
+
 	private void ButtonClick(Enums.MenuItem item)
 	{
 		OnMenuItemSelected.InvokeAsync(item);

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/Navbar.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/Navbar.razor
@@ -24,7 +24,7 @@
 			</div>
 
 			<div class="px-1">
-				<Picker CurrentBCV="CurrentBCV" OnBCVSelected="ReturnedBCV" ShowDebugPicker="ShowDebugPicker" />
+				<Picker CurrentBCV="CurrentBCV" OnBCVSelected="ReturnedBCV" />
 			</div>
 
 			<div class="">
@@ -48,7 +48,6 @@
 
 	// Only used by <Picker>
 	[Parameter, EditorRequired] public NumberPad.BookChapterVerse? CurrentBCV { get; set; }
-	[Parameter, EditorRequired] public bool ShowDebugPicker { get; set; }
 	
 	[Parameter, EditorRequired] public EventCallback<NumberPad.BookChapterVerse> OnBCVSelected { get; set; }
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ButtonWrapper.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ButtonWrapper.razor
@@ -101,9 +101,8 @@
 
 @code {
 	[Parameter, EditorRequired] public GlobalEnums.BibleBook? BibleBook { get; set; }
-	[Parameter, EditorRequired] public bool ShowDebugPicker { get; set; }
 	[Parameter, EditorRequired] public EventCallback<BookChapterVerse> OnBCVSelected { get; set; }
-
+	[CascadingParameter] public CascadingAppState? State { get; set; }
 
 	protected int SelectedVerse = 0; // ToDo: are you going to use this or not.
 	protected StepState? StepState { get; set; }
@@ -117,7 +116,7 @@
 	{
 		//StepState = new StepState(BibleBook);
 		StepState = new StepState(BibleBook, Logger!);
-		IsDebug = ShowDebugPicker;	
+		IsDebug = State!.AppState!.BookChapterState!.GetPickerDebug(); 
 	}
 
 	private void OnHundredNumberSelected(int number)

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ChapterTensAndOnesButtons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/ChapterTensAndOnesButtons.razor
@@ -1,21 +1,21 @@
 ﻿@inject ILoggerFactory LoggerFactory
 
 <!-- 1st row GetZeroButtonClass -->
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button class="@Helper.GetButtonClassEmptyNoColor()">&nbsp;</button>
 	<button id="@GetId(0)" title="@GetId(0)" class="@GetZeroButtonClass()" @onclick="() => ButtonClick(0)">0</button>
 	<button class="@Helper.GetButtonClassEmptyNoColor()">&nbsp;</button>
 </div>
 
 <!-- 2nd row Cols 1-3 -->
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button id="@GetId(1)" title="@GetId(1)" class="@GetButtonClass(1)" @onclick="() => ButtonClick(1)">1</button>
 	<button id="@GetId(2)" title="@GetId(2)" class="@GetButtonClass(2)" @onclick="() => ButtonClick(2)">2</button>
 	<button id="@GetId(3)" title="@GetId(3)" class="@GetButtonClass(3)" @onclick="() => ButtonClick(3)">3</button>
 </div>
 
 <!-- 3rd row Cols 4-6 -->
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button id="@GetId(4)" title="@GetId(4)" class="@GetButtonClass(4)" @onclick="() => ButtonClick(4)">4</button>
 	<button id="@GetId(5)" title="@GetId(5)" class="@GetButtonClass(5)" @onclick="() => ButtonClick(5)">5</button>
 	<button id="@GetId(6)" title="@GetId(6)" class="@GetButtonClass(6)" @onclick="() => ButtonClick(6)">6</button>
@@ -39,6 +39,28 @@
 		Logger = LoggerFactory.CreateLogger($"{nameof(ChapterTensAndOnesButtons)}");
 	}
 
+	int SelectedTensPlace = 0;
+	int MaxTensPlace = 0;
+	int MaxOnesPlace = 0;
+
+	protected override void OnParametersSet()
+	{
+		Logger!.LogInformation("{Method}, LC: {LastChapter}", nameof(OnParametersSet), StepState!.LastChapter);
+
+		MaxTensPlace = (StepState!.LastChapter / 10) % 10;
+		SelectedTensPlace = StepState!.PlaceValueRec!.Tens is not null ? (int)StepState!.PlaceValueRec!.Tens! : 0;
+
+		int onesDigit = 0;
+		if (StepState!.Step!.Place == Enums.Place.Ones)
+		{
+			onesDigit = StepState!.LastChapter % 10;
+			if (onesDigit == 0) onesDigit = 10;
+			MaxOnesPlace = onesDigit;
+		}
+		Logger!.LogWarning("...TensPlace Selected {SelectedTensPlace}/Max: {MaxTensPlace}; MaxOnesPlace: {MaxOnesPlace}"
+	, SelectedTensPlace, MaxTensPlace, MaxOnesPlace);
+	}
+
 	protected string GetButtonClass(int number)
 	{
 		@if (StepState!.Step!.Place == Enums.Place.Tens)
@@ -57,34 +79,36 @@
 		{
 			if (number == LastTensPlaceIsWhole)
 			{
-				return $"btn {Helper.GetButtonColor(LastTensPlaceIsWhole)} {Helper.GetDefaultButtonClass()}";
+				return $"btn {Helper.GetButtonColor(LastTensPlaceIsWhole)} {Helper.GetDefaultButtonClass()} {Helper.colPadding}";
 			}
 			else
 			{
-				return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
+				return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()} {Helper.colPadding}";
 			}
 		}
 		else
 		{
-			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
+			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()} {Helper.colPadding}";
 		}
 
 	}
 
 	private string GetOnesPlaceButtonClass(int number)
 	{
-		int one = 0;
-
-		if (StepState!.PlaceValueRec!.IsWhole) { one = 9; }
-		else { one = StepState!.PlaceValueRec!.Ones; }
-
-		if (number <= one)
+		if (SelectedTensPlace < MaxTensPlace)
 		{
 			return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
 		}
 		else
 		{
-			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
+			if (number <= MaxOnesPlace)
+			{
+				return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
+			}
+			else
+			{
+				return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
+			}
 		}
 	}
 
@@ -99,7 +123,6 @@
 			return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
 		}
 	}
-
 
 	private string GetId(int number)
 	{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/Helper.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/Helper.cs
@@ -8,12 +8,12 @@ public class Helper
 
 	public static string GetButtonClassEmpty()
 	{
-		return $"btn {BtnOutlineColors.Secondary} disabled {fontType} {fontSize}";
+		return $"btn {BtnOutlineColors.Secondary} disabled {fontType} {fontSize} {Helper.colPadding}";
 	}
 
 	public static string GetButtonClassEmptyNoColor()
 	{
-		return $"btn {fontType} {fontSize}";
+		return $"btn {fontType} {fontSize} {Helper.colPadding}";
 	}
 
 	public static string GetDefaultButtonClass(bool small = false)
@@ -29,7 +29,9 @@ public class Helper
 
 	public static string GetButtonColor(int lastChapterIsWhole)
 	{
-		return lastChapterIsWhole==0 ? BtnOutlineColors.Info : BtnOutlineColors.Primary;
+		//return lastChapterIsWhole==0 ? BtnOutlineColors.Info : BtnOutlineColors.Primary;
+		return lastChapterIsWhole == 0 ? BtnOutlineColors.Primary : BtnOutlineColors.Info;
+		//return lastChapterIsWhole == 0 ? BtnColors.Primary : BtnColors.Info;
 	}
 
 	const string fontType = "font-monospace";
@@ -37,9 +39,15 @@ public class Helper
 	const string fontSizeSmall = "fs-5";
 
 
+	//public const string rowPadding = "mb-1";
+	//public const string colPadding = "me-1";
+	public const string rowPadding = "";
+	public const string colPadding = "";
+
+
 	#region LastVerse
 	//Imported from what was called LastVerseHelper
-	
+
 	// Called by StepState!ChangeCurrentStep! case Direction.GoToSecondPhase:
 	public static int GetLastVerse(BibleBookEnum.BibleBook? bibleBook, int chapter)
 	{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/IntegerPlaceHolder.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/IntegerPlaceHolder.razor
@@ -1,17 +1,17 @@
 ﻿
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button class="@Helper.GetButtonClassEmptyNoColor()">&nbsp;</button>
 	<button type="button" class="@Helper.GetButtonClassEmpty()">0</button>
 	<button class="@Helper.GetButtonClassEmptyNoColor()">&nbsp;</button>
 </div>
 
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button type="button" class="@Helper.GetButtonClassEmpty()">1</button>
 	<button type="button" class="@Helper.GetButtonClassEmpty()">2</button>
 	<button type="button" class="@Helper.GetButtonClassEmpty()">3</button>
 </div>
 
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button type="button" class="@Helper.GetButtonClassEmpty()">4</button>
 	<button type="button" class="@Helper.GetButtonClassEmpty()">5</button>
 	<button type="button" class="@Helper.GetButtonClassEmpty()">6</button>

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/Picker.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/Picker.razor
@@ -54,8 +54,6 @@ else
 					<ButtonWrapper BibleBook="SelectedBook" OnBCVSelected="ReturnedBCV" />
 				</div>
 
-				@* 				<div class="modal-footer @modalFooterColor">	</div> *@
-
 			</div>
 		</div>
 	</div>
@@ -63,7 +61,6 @@ else
 
 @code {
 	[Parameter, EditorRequired] public BookChapterVerse? CurrentBCV { get; set; }
-	[Parameter, EditorRequired] public bool ShowDebugPicker { get; set; }
 	[Parameter] public EventCallback<BookChapterVerse> OnBCVSelected { get; set; }
 
 	protected BibleBookEnum.BibleBook? SelectedBook { get; set; }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/StepState.cs
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/StepState.cs
@@ -65,7 +65,7 @@ public class StepState
 
 	public void UpdatePlaceValueRecForTens(int number)
 	{
-		Logger!.LogInformation("{Method}, XXXXXX number: {number}", nameof(UpdatePlaceValueRecForTens), number);
+		Logger!.LogInformation("{Method}, number: {number}", nameof(UpdatePlaceValueRecForTens), number);
 		PlaceValueRec = PlaceValueRec! with { Tens = number, Mask = $"{PlaceValueRec.Hundreds}{number}X" };
 	}
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/VerseTensAndOnesButtons.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/BookChapter/Toolbar/NumberPad/VerseTensAndOnesButtons.razor
@@ -1,22 +1,21 @@
-﻿
-@inject ILoggerFactory LoggerFactory
+﻿@inject ILoggerFactory LoggerFactory
 
 <!-- 1st row GetZeroButtonClass -->
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button class="@Helper.GetButtonClassEmptyNoColor()">&nbsp;</button>
 	<button id="@GetId(0)" title="@GetId(0)" class="@GetZeroButtonClass()" @onclick="() => ButtonClick(0)">0</button>
 	<button class="@Helper.GetButtonClassEmptyNoColor()">&nbsp;</button>
 </div>
 
 <!-- 2nd row Cols 1-3 -->
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button id="@GetId(1)" title="@GetId(1)" class="@GetButtonClass(1)" @onclick="() => ButtonClick(1)">1</button>
 	<button id="@GetId(2)" title="@GetId(2)" class="@GetButtonClass(2)" @onclick="() => ButtonClick(2)">2</button>
 	<button id="@GetId(3)" title="@GetId(3)" class="@GetButtonClass(3)" @onclick="() => ButtonClick(3)">3</button>
 </div>
 
 <!-- 3rd row Cols 4-6 -->
-<div class="d-flex justify-content-center">
+<div class="d-flex justify-content-center @Helper.rowPadding">
 	<button id="@GetId(4)" title="@GetId(4)" class="@GetButtonClass(4)" @onclick="() => ButtonClick(4)">4</button>
 	<button id="@GetId(5)" title="@GetId(5)" class="@GetButtonClass(5)" @onclick="() => ButtonClick(5)">5</button>
 	<button id="@GetId(6)" title="@GetId(6)" class="@GetButtonClass(6)" @onclick="() => ButtonClick(6)">6</button>
@@ -29,24 +28,20 @@
 	<button id="@GetId(9)" title="@GetId(9)" class="@GetButtonClass(9)" @onclick="() => ButtonClick(9)">9</button>
 </div>
 
-
 @code {
-
 	[Parameter, EditorRequired] public StepState? StepState { get; set; }
-	//[Parameter, EditorRequired] public int WHAT-GOES-HERE { get; set; } // If 0 then like being null
 	[Parameter, EditorRequired] public int LastTensPlaceIsWhole { get; set; } // If 0 then like being null
 	[Parameter, EditorRequired] public EventCallback<ReturnedVerseNumberVM> OnNumberSelected { get; set; }
-
-	int SelectedTensPlace = 0;
-	int MaxTensPlace = 0;
-	int MaxOnesPlace = 0;
-
 
 	private ILogger? Logger;
 	protected override void OnInitialized()
 	{
 		Logger = LoggerFactory.CreateLogger($"{nameof(VerseTensAndOnesButtons)}");
 	}
+
+	int SelectedTensPlace = 0;
+	int MaxTensPlace = 0;
+	int MaxOnesPlace = 0;
 
 	protected override void OnParametersSet()
 	{
@@ -62,7 +57,6 @@
 			if (onesDigit == 0) onesDigit = 10;
 			MaxOnesPlace = onesDigit;
 		}
-
 		Logger!.LogWarning("...TensPlace Selected {SelectedTensPlace}/Max: {MaxTensPlace}; MaxOnesPlace: {MaxOnesPlace}"
 		, SelectedTensPlace, MaxTensPlace, MaxOnesPlace);
 	}
@@ -85,16 +79,16 @@
 		{
 			if (number == LastTensPlaceIsWhole)
 			{
-				return $"btn {Helper.GetButtonColor(LastTensPlaceIsWhole)} {Helper.GetDefaultButtonClass()}";
+				return $"btn {Helper.GetButtonColor(LastTensPlaceIsWhole)} {Helper.GetDefaultButtonClass()} {Helper.colPadding}";
 			}
 			else
 			{
-				return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()}";
+				return $"btn {Helper.GetButtonColor(0)} {Helper.GetDefaultButtonClass()} {Helper.colPadding}";
 			}
 		}
 		else
 		{
-			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()}";
+			return $"btn {Helper.GetDisabledColor()} disabled  {Helper.GetDefaultButtonClass()} {Helper.colPadding}";
 		}
 
 	}
@@ -163,5 +157,4 @@
 			Logger!.LogError(ex, "Error in {Method}", nameof(ButtonClick));
 		}
 	}
-
 }


### PR DESCRIPTION
# Commit | branch: john-069-TensAndOnesButtons-Phase-Split (#2)

# Bug Fix
- [x] `GetOnesPlaceButtonClass` not showing all available single digits to be shown, e.g.

### buttons in yellow are being shown

![Joh-Bug](https://github.com/user-attachments/assets/fb1e512a-e84f-402e-b011-b3f9a4261b1a)


Code very similar to `GetOnesPlaceButtonClass` of `VersesTensAndOnesButtons` was used.

# Features
- [x] Added abstraction to `Helper.cs` to show alternative Button Colors and Spacing
- [x] Got the `Show Debug` menu item working
- [ ] Add a History state to Menu
- [ ] Change focus with going through the Steps
  - [ ] Maybe have a 'focus' box that moves 
- [ ] Get logging working with `StepState`
- [ ] Get `Step Back` button working



#### Messing with Button Colors and Spacing

![Messing-with-Button-Colors-and-Spacing](https://github.com/user-attachments/assets/552f6fb2-03cf-4770-b6f5-1331e2788d10)
