### PR TITLE
Haggadah Index simplification

### DIFF
--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Index.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Index.razor
@@ -1,11 +1,9 @@
 ﻿@page "/Haggadah"
 
-@using MyHebrewBible.Client.Features.Haggadah.Enums
 @using MyHebrewBible.Client.Features.Haggadah.Toolbar
 @using Page = MyHebrewBible.Client.Enums.Nav
 @using MyHebrewBible.Client.Layout
-@using MyHebrewBible.Client.Components.Toolbar
-@using MyHebrewBible.Client.Helpers
+@using MyHebrewBible.Client.Enums;
 
 @inject IToastService? Toast
 @inject ILogger<Index>? Logger
@@ -14,55 +12,45 @@
 
 <NavbarSkeleton>
 
-	<HomeButtonContent><HomeButton /></HomeButtonContent>
+	<JustifyStart><HomeButton /></JustifyStart>
 
-	<PrevButtonContent>
-		@if (Section != 1)
-		{
-			<PreviousOrNextButton Section="Section"
-														Forward=false
-														OnSectionSelected="ReturnedSection" />
-		}
-		else
-		{
-			<OnEdgeButton />
-		}
-	</PrevButtonContent>
+	<PrevButtonDiv>
+		<PreviousOrNextButton Section="Section"
+													Forward=false
+													OnSectionSelected="ReturnedSection" />
+	</PrevButtonDiv>
 
-	<ProgressBarContent>
-		<Progressbar Section="Section" />
-	</ProgressBarContent>
+	<ProgressBarDiv>
+		<div class="@MediaQuery.XsOrSm.DivClass">
+			<Progressbar Section="Section" IsXsOrSm=true />
+		</div>
+		<div class="@MediaQuery.MdOrLgOrXl.DivClass">
+			<Progressbar Section="Section" IsXsOrSm=false />
+		</div>
+	</ProgressBarDiv>
 
-	<NextButtonContent>
-		@if (Section < Enums.Content.List.Count)
-		{
-			<PreviousOrNextButton Section="Section"
-														Forward=true
-														OnSectionSelected="ReturnedSection" />
-		}
-		else
-		{
-			<OnEdgeButton />
-		}
-	</NextButtonContent>
+	<NextButtonDiv>
+		<PreviousOrNextButton Section="Section"
+													Forward=true
+													OnSectionSelected="ReturnedSection" />
+	</NextButtonDiv>
 
-	<RightMenuContent>
-		<RightMenuSkeleton OnSectionSelected="ReturnedSection">
-			<LanguageButtonsContent>
-				@foreach (var item in Enums.DisplayLanguage.List.OrderBy(o => o.Value))
-				{
-					<li class="dropdown-item">
-						<button @onclick="@(e => ReturnedMenuItem(item))"
-										type="button" class="btn btn-outline-primary">
-							@item.Title
-						</button>
-					</li>
-				}
-			</LanguageButtonsContent>
+	<JustifyEnd>
+		<RightMenuSkeleton>
+			<LanguageItems>
+				<LanguagePicker OnLanguageSelected="ReturnedLanguageMenuItem" />
+			</LanguageItems>
+			<TocButton>
+				<TableOfContentToggle OnOpen="FlipToggle" />
+			</TocButton>
 		</RightMenuSkeleton>
-	</RightMenuContent>
+	</JustifyEnd>
 
 </NavbarSkeleton>
+
+<ToCModal IsVisible="ShowTableOfContentModal"
+					OnSectionSelected="ReturnedSection"
+					OnClose="FlipToggle" />	/>
 
 <LoadingProgress>
 	<div class="mt-5">
@@ -94,6 +82,13 @@
 
 @code {
 	[CascadingParameter] public CascadingAppState? State { get; set; }
+
+	protected bool ShowTableOfContentModal = false;
+	private void FlipToggle()
+	{
+		ShowTableOfContentModal = !ShowTableOfContentModal;
+	}
+
 
 	protected int Section;
 	protected Enums.Content? CurrentContent;
@@ -161,7 +156,7 @@
 		}
 	}
 
-	private async Task ReturnedMenuItem(Enums.DisplayLanguage item)
+	private async Task ReturnedLanguageMenuItem(Enums.DisplayLanguage item)
 	{
 		Language = item;
 		await State!.AppState!.HaggadahState!.UpdateLanguage(item);
@@ -171,6 +166,7 @@
 	{
 		Section = section;
 		CurrentContent = Enums.Content.List.FirstOrDefault(w => w.Value == Section);
+		ShowTableOfContentModal = false;
 		SetDetail();
 		// save to local storage
 	}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/LanguagePicker.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/LanguagePicker.razor
@@ -1,0 +1,20 @@
+﻿@using MyHebrewBible.Client.Helpers
+
+@foreach (var item in Enums.DisplayLanguage.List.OrderBy(o => o.Value))
+{
+	<li class="dropdown-item">
+		<button @onclick="@(e => ButtonClick(item))"
+						type="button" class="btn @BtnOutlineColors.Primary">
+			@item.Title
+		</button>
+	</li>
+}
+
+@code {
+	[Parameter, EditorRequired] public EventCallback<Enums.DisplayLanguage> OnLanguageSelected { get; set; }
+
+	private void ButtonClick(Enums.DisplayLanguage language)
+	{
+		OnLanguageSelected.InvokeAsync(language);
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/NavbarSkeleton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/NavbarSkeleton.razor
@@ -1,44 +1,40 @@
-﻿@using MyHebrewBible.Client.Layout
-@using MyHebrewBible.Client.Helpers
+﻿<nav class="navbar navbar-expand bg-primary-subtle fixed-top">
 
-<nav class="navbar navbar-expand bg-primary-subtle fixed-top">
-	
 	<div class="d-flex justify-content-start">
 
 		<div class="px-1">
-			@HomeButtonContent
+			@JustifyStart
 		</div>
 	</div>
 
 	<div class="collapse navbar-collapse justify-content-between">
 
 		<div class="px-1">
-			@PrevButtonContent
+			@PrevButtonDiv
 		</div>
 
 		<div class="col">
-			@ProgressBarContent
+			@ProgressBarDiv
 		</div>
+
 		<div class="px-1">
-			@NextButtonContent
+			@NextButtonDiv
 		</div>
 
 	</div>
 
 	<div class="d-flex justify-content-end pe-1">
-		<div class="">
-			@RightMenuContent
-		</div>
+		@JustifyEnd
 	</div>
 
 </nav>
 <br />
 
 @code {
-	[Parameter] public RenderFragment? HomeButtonContent { get; set; }
-	[Parameter] public RenderFragment? PrevButtonContent { get; set; }
-	[Parameter] public RenderFragment? ProgressBarContent { get; set; }
-	[Parameter] public RenderFragment? NextButtonContent { get; set; }
-	[Parameter] public RenderFragment? RightMenuContent { get; set; }
+	[Parameter] public RenderFragment? JustifyStart { get; set; }
+	[Parameter] public RenderFragment? PrevButtonDiv { get; set; }
+	[Parameter] public RenderFragment? ProgressBarDiv { get; set; }
+	[Parameter] public RenderFragment? NextButtonDiv { get; set; }
+	[Parameter] public RenderFragment? JustifyEnd { get; set; }
 
 }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/PreviousOrNextButton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/PreviousOrNextButton.razor
@@ -1,10 +1,36 @@
 ﻿@using MyHebrewBible.Client.Helpers
+@using MyHebrewBible.Client.Components.Toolbar
 
-<button type="button" class="btn @BtnOutlineColors.Primary @BtnSize.Md @Margin"
-				title="Section: @Section"
-				@onclick="ButtonClick">
-	<i class="@Icon"></i>
-</button>
+@if (Forward)
+{
+	if (Section < Enums.Content.List.Count)
+	{
+		<button type="button" class="btn @BtnOutlineColors.Primary @BtnSize.Md @Margin"
+						title="Section: @Section"
+						@onclick="ButtonClick">
+			<i class="@Icon"></i>
+		</button>
+	}
+	else
+	{
+		<OnEdgeButton />
+	}
+}
+else
+{
+	if (Section != 1)
+	{
+		<button type="button" class="btn @BtnOutlineColors.Primary @BtnSize.Md @Margin"
+						title="Section: @Section"
+						@onclick="ButtonClick">
+			<i class="@Icon"></i>
+		</button>
+	}
+	else
+	{
+		<OnEdgeButton />
+	}
+}
 
 @code {
 	[Parameter, EditorRequired] public int Section { get; set; }

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/Progressbar.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/Progressbar.razor
@@ -2,13 +2,16 @@
 
 <div class="progress" style="height: 40px;">
 	<div class="progress-bar @BgAndText.Info" style='@GetProgressStyle()'>
-		<span class="fs-4 fw-bold">@GetProgressPercent()</span>
+		<span class="@SpanCSS">@GetProgressPercent()</span>
 	</div>
 </div>
 
 @code {
 
 	[Parameter, EditorRequired] public int Section { get; set; }
+	[Parameter, EditorRequired] public bool IsXsOrSm { get; set; }
+
+	protected string SpanCSS => IsXsOrSm ? "" : "fs-4 fw-bold";
 
 	protected string GetProgressStyle()
 	{

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/RightMenuSkeleton.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/RightMenuSkeleton.razor
@@ -9,39 +9,22 @@
 	<ul class="dropdown-menu">
 
 		<li class="fw-bold dropdown-header">Language</li>
-		
-		@LanguageButtonsContent
+			@LanguageItems
 
 		<li><hr class="dropdown-divider"></li>
 
+		<li class="fw-bold dropdown-header">Navigate</li>
+
 		<li class="dropdown-item">
-			<button type="button" class="btn btn-outline-primary" title="Table of Contents"
-							@onclick="ButtonClickShowTableOfContent">
-				Table of Content
-			</button>
+			@TocButton
 		</li>
 	</ul>
 
 </div>
 
-@if (ShowTableOfContentModal) { 
-	<ToCModal OnSectionSelected="ReturnedSection" />
-}
-
 @code {
-	[Parameter] public RenderFragment? LanguageButtonsContent { get; set; }
-	[Parameter, EditorRequired] public EventCallback<int> OnSectionSelected { get; set; }
-
-	protected bool ShowTableOfContentModal = false;
-	private void ButtonClickShowTableOfContent()
-	{
-		ShowTableOfContentModal = !ShowTableOfContentModal;
-	}
-
-	private void ReturnedSection(int section)
-	{
-		ShowTableOfContentModal = !ShowTableOfContentModal;
-		OnSectionSelected.InvokeAsync(section);
-	}
+	[Parameter, EditorRequired] public RenderFragment? LanguageItems { get; set; }
+	[Parameter, EditorRequired] public RenderFragment? TocButton { get; set; }
+	
 }
 

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/TableOfContentToggle.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/TableOfContentToggle.razor
@@ -1,0 +1,15 @@
+﻿@using MyHebrewBible.Client.Helpers
+
+<button type="button" class="btn @BtnOutlineColors.Primary" title="Table of Contents"
+				@onclick="ButtonClick">
+	Table of Content
+</button>
+
+@code {
+	[Parameter, EditorRequired] public EventCallback OnOpen { get; set; }
+
+	private void ButtonClick()
+	{
+		OnOpen.InvokeAsync();
+	}
+}

--- a/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/ToCModal.razor
+++ b/MyHebrewBible/MyHebrewBible.Client/Features/Haggadah/Toolbar/ToCModal.razor
@@ -1,58 +1,48 @@
-﻿
-<div class="@modalClass" style="display:@(modalOpen?"block":"none");">
-	<div class="modal-dialog modal-md">
-		<div class="modal-content">
-			<div class="modal-header @headerBackGround">
+﻿@using MyHebrewBible.Client.Helpers
+
+@if(IsVisible)
+{
+	<div class="modal show" style="display:block;">
+		<div class="modal-dialog modal-md">
+			<div class="modal-content">
+				<div class="modal-header @BgAndText.Warning">
 
 					<p class="fs-5 modal-title">Table of Contents</p>
+					 <button type="button" class="close" @onclick="ButtonClickClose"><span>&times;</span></button> 
+				</div>
 
-				<button type="button" class="close" @onclick="CloseModal">
-					<span>&times;</span>
-				</button>
-			</div>
+				<div class="modal-body @BgAndText.WarningSubtle">
+					<ol class="fs-5">
+						@foreach (var item in Enums.Content.List.OrderBy(o => o.Value))
+						{
+							<li>
+								<a class="text-decoration-underline"
+									 @onclick="@(() => ButtonClickSelect(item.Value))"
+									 title="@item.Value">
+									@item.Title
+								</a>
+							</li>
+						}
+					</ol>
 
-			<div class="modal-body @bodyBackGround">
-				<ol class="fs-5">
-					@foreach (var item in Enums.Content.List.OrderBy(o => o.Value))
-					{
-						<li>
-								<a class="text-decoration-underline" @onclick="@(() => ButtonClick(item.Value))" title="@item.Value">@item.Title </a>
-						</li>
-					}
-				</ol>
-
+				</div>
 			</div>
 		</div>
 	</div>
-</div>
+}
 
 @code {
+	[Parameter, EditorRequired] public bool IsVisible { get; set; }
 	[Parameter, EditorRequired] public EventCallback<int> OnSectionSelected { get; set; }
+	[Parameter, EditorRequired] public EventCallback OnClose { get; set; }
 
-	bool modalOpen = true;
-	string modalClass = "modal show";
-	string headerBackGround = "bg-warning";
-	string bodyBackGround = "bg-warning-subtle";
-	bool ModalIsNotShownToggle = true;
-
-	protected void ShowModal()
+	private void ButtonClickClose()
 	{
-		modalOpen = true;
-		ModalIsNotShownToggle = false;
-		modalClass += " show";
-		StateHasChanged();
+		OnClose.InvokeAsync();
 	}
 
-	void CloseModal()
+	private void ButtonClickSelect(int value)
 	{
-		modalOpen = false;
-		ModalIsNotShownToggle = true;
-		modalClass = "modal";
-	}
-
-	private void ButtonClick(int value)
-	{
-		CloseModal();
 		OnSectionSelected.InvokeAsync(value);
 	}
 }


### PR DESCRIPTION
## `Index` Simplification
Simplified by...
-  ...removing implementation details down the hierarchy
-  ...these details were replaced with well named child components effectively moving up the hierarchy a better understanding of what's going on.
-  ...the newly created components were created by using the single responsibility pattern. this simplified `EventCallback` communications back to the index

### `PreviousOrNextButton` 


###  `RightMenuContent` 


### Pushed details from `RightMenuSkeleton` to child components
- `LanguagePicker`
- `TableOfContentToggle` 

# Index `NavbarSkeleton`

![Index-NavbarSkeleton](https://github.com/user-attachments/assets/434536e8-24f3-4388-b1e7-4b644db5c239)

